### PR TITLE
Support for displacement surface flags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>bspsrc</artifactId>
     <groupId>info.ata4.bspsrc</groupId>
     <packaging>jar</packaging>
-    <version>1.3.24-SNAPSHOT</version>
+    <version>1.3.25u-SNAPSHOT</version>
     <description>A Source engine map decompile</description>
     <url>https://github.com/ata4/bspsource</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>bspsrc</artifactId>
     <groupId>info.ata4.bspsrc</groupId>
     <packaging>jar</packaging>
-    <version>1.3.23-SNAPSHOT</version>
+    <version>1.3.24-SNAPSHOT</version>
     <description>A Source engine map decompile</description>
     <url>https://github.com/ata4/bspsource</url>
   

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>bspsrc</artifactId>
     <groupId>info.ata4.bspsrc</groupId>
     <packaging>jar</packaging>
-    <version>1.3.25u-SNAPSHOT</version>
+    <version>1.3.26u-SNAPSHOT</version>
     <description>A Source engine map decompile</description>
     <url>https://github.com/ata4/bspsource</url>
   

--- a/src/main/java/info/ata4/bsplib/struct/DDispInfo.java
+++ b/src/main/java/info/ata4/bsplib/struct/DDispInfo.java
@@ -96,4 +96,12 @@ public class DDispInfo implements DStruct {
     public boolean hasMultiBlend() {
         return ((minTess + DDispInfo.DISP_INFO_FLAG_MAGIC) & DDispInfo.DISP_INFO_FLAG_HAS_MULTIBLEND) != 0;
     }
+
+    public int getSurfaceFlags() {
+        if ((minTess & DDispInfo.DISP_INFO_FLAG_MAGIC) != 0) {
+            return minTess & ~DDispInfo.DISP_INFO_FLAG_MAGIC;
+        } else {
+            return 0;
+        }
+    }
 }

--- a/src/main/java/info/ata4/bspsrc/BspSource.java
+++ b/src/main/java/info/ata4/bspsrc/BspSource.java
@@ -35,7 +35,7 @@ public class BspSource implements Runnable {
     
     private static final Logger L = LogUtils.getLogger();
 
-    public static final String VERSION = "1.3.25u";
+    public static final String VERSION = "1.3.26u";
     
     private final BspSourceConfig config;
     

--- a/src/main/java/info/ata4/bspsrc/BspSource.java
+++ b/src/main/java/info/ata4/bspsrc/BspSource.java
@@ -35,7 +35,7 @@ public class BspSource implements Runnable {
     
     private static final Logger L = LogUtils.getLogger();
 
-    public static final String VERSION = "1.3.23";
+    public static final String VERSION = "1.3.24";
     
     private final BspSourceConfig config;
     

--- a/src/main/java/info/ata4/bspsrc/BspSource.java
+++ b/src/main/java/info/ata4/bspsrc/BspSource.java
@@ -35,7 +35,7 @@ public class BspSource implements Runnable {
     
     private static final Logger L = LogUtils.getLogger();
 
-    public static final String VERSION = "1.3.24";
+    public static final String VERSION = "1.3.25u";
     
     private final BspSourceConfig config;
     

--- a/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
+++ b/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
@@ -61,7 +61,7 @@ public final class BspSourceConfig implements Serializable {
     public boolean writeStaticProps = true;
     public boolean writeVisgroups = true;
     public boolean writeWorldBrushes = true;
-    public boolean writeLadders = true;
+    public boolean writeLaddersAsEntities = false;
     
     private boolean debug = false;
     private Set<BspFileEntry> files = new HashSet<>();

--- a/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
+++ b/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
@@ -62,6 +62,7 @@ public final class BspSourceConfig implements Serializable {
     public boolean writeVisgroups = true;
     public boolean writeWorldBrushes = true;
     public boolean writeLaddersAsEntities = false;
+    public boolean addUseLandmarkAngles = false;
     
     private boolean debug = false;
     private Set<BspFileEntry> files = new HashSet<>();

--- a/src/main/java/info/ata4/bspsrc/cli/BspSourceCli.java
+++ b/src/main/java/info/ata4/bspsrc/cli/BspSourceCli.java
@@ -275,7 +275,7 @@ public class BspSourceCli {
             config.writeOccluders = !cl.hasOption(nocclOpt.getOpt());
             config.writeCubemaps = !cl.hasOption(ncubemOpt.getOpt());
             config.writeDetails = !cl.hasOption(ndetailsOpt.getOpt());
-            config.writeLadders = !cl.hasOption(nladderOpt.getOpt());
+            config.writeLaddersAsEntities = !cl.hasOption(nladderOpt.getOpt());
             
             // world options
             config.writeWorldBrushes = !cl.hasOption(nbrushOpt.getOpt());

--- a/src/main/java/info/ata4/bspsrc/cli/BspSourceCli.java
+++ b/src/main/java/info/ata4/bspsrc/cli/BspSourceCli.java
@@ -131,7 +131,7 @@ public class BspSourceCli {
             .create('l'));
 
         // entity options
-        Option nbentsOpt, npentsOpt, npropsOpt, noverlOpt, ncubemOpt, ndetailsOpt, nareapOpt, nocclOpt, nladderOpt, nrotfixOpt;
+        Option nbentsOpt, npentsOpt, npropsOpt, noverlOpt, ncubemOpt, ndetailsOpt, nareapOpt, nocclOpt, nladderOpt, nULAOpt, nrotfixOpt;
         optsEntity.addOption(npentsOpt = new Option("no_point_ents", "Don't write any point entities."));
         optsEntity.addOption(nbentsOpt = new Option("no_brush_ents", "Don't write any brush entities."));
         optsEntity.addOption(npropsOpt = new Option("no_sprp", "Don't write prop_static entities."));
@@ -141,6 +141,7 @@ public class BspSourceCli {
         optsEntity.addOption(nareapOpt = new Option("no_areaportals", "Don't write func_areaportal(_window) entities."));
         optsEntity.addOption(nocclOpt = new Option("no_occluders", "Don't write func_occluder entities."));
         optsEntity.addOption(nladderOpt = new Option("no_ladders", "Don't write func_ladder entities."));
+        optsEntity.addOption(nULAOpt = new Option("add_uselandmarkangles", "Add UseLandmarkAngles key to teleporters."));
         optsEntity.addOption(nrotfixOpt = new Option("no_rotfix", "Don't fix instance entity brush rotations for Hammer."));
         
         // world brush options
@@ -276,6 +277,7 @@ public class BspSourceCli {
             config.writeCubemaps = !cl.hasOption(ncubemOpt.getOpt());
             config.writeDetails = !cl.hasOption(ndetailsOpt.getOpt());
             config.writeLaddersAsEntities = !cl.hasOption(nladderOpt.getOpt());
+            config.addUseLandmarkAngles = cl.hasOption(nULAOpt.getOpt());
             
             // world options
             config.writeWorldBrushes = !cl.hasOption(nbrushOpt.getOpt());

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
@@ -498,6 +498,7 @@
                 <Component class="javax.swing.JCheckBox" name="checkBoxLadder">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="func_ladder"/>
+                    <Property name="toolTipText" type="java.lang.String" value="&lt;html&gt;Writes ladders as func_ladder entities.&lt;br&gt;Do not use if you intend to recompile for CSGO!&lt;/html&gt;"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxLadderActionPerformed"/>

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
@@ -510,7 +510,7 @@
                 <Component class="javax.swing.JCheckBox" name="checkBoxAddUseLandmarkAngles">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Add UseLandmarkAngles"/>
-                    <Property name="toolTipText" type="java.lang.String" value="&lt;html&gt;&#xa;Adds &quot;UseLandmarkAngles 1&quot; to trigger_teleport entities that have no value set&lt;br&gt;&#xa;and also do not have a landmark specified. Older games do not use this key and&lt;br&gt;&#xa;instead treat it as if the value is 1, except when a landmark is set. Use this to&lt;br&gt;&#xa;ensure consistant behavior when recompiling maps from older games for newer ones.&#xa;&lt;/html&gt;"/>
+                    <Property name="toolTipText" type="java.lang.String" value="&lt;html&gt;&#xa;Adds &quot;UseLandmarkAngles 1&quot; to trigger_teleport entities that have no value set&lt;br&gt;&#xa;and also do not have a landmark specified. Older games do not use this key and&lt;br&gt;&#xa;instead treat it as if the value is 1, except when a landmark is set. Use this to&lt;br&gt;&#xa;ensure consistent behavior when recompiling maps from older games for newer ones.&#xa;&lt;/html&gt;"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxAddUseLandmarkAnglesActionPerformed"/>

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
@@ -497,7 +497,7 @@
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="checkBoxLadder">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="func_ladder"/>
+                    <Property name="text" type="java.lang.String" value="Ladders as func_ladder"/>
                     <Property name="toolTipText" type="java.lang.String" value="&lt;html&gt;Writes ladders as func_ladder entities.&lt;br&gt;Do not use if you intend to recompile for CSGO!&lt;/html&gt;"/>
                   </Properties>
                   <Events>

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
@@ -98,7 +98,7 @@
                   <Group type="102" alignment="0" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="scrollFiles" pref="158" max="32767" attributes="0"/>
+                          <Component id="scrollFiles" pref="181" max="32767" attributes="0"/>
                           <Group type="102" attributes="0">
                               <Component id="buttonAdd" min="-2" max="-2" attributes="0"/>
                               <EmptySpace max="-2" attributes="0"/>
@@ -198,7 +198,7 @@
                           <Component id="checkBoxDisp" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="panelBrushMode" alignment="0" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace pref="41" max="32767" attributes="0"/>
+                      <EmptySpace pref="64" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -438,6 +438,7 @@
                               <Component id="checkBoxOccluder" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="checkBoxFixRotation" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="checkBoxLadder" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="checkBoxAddUseLandmarkAngles" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace max="32767" attributes="0"/>
                       </Group>
@@ -456,6 +457,8 @@
                           <Component id="checkBoxLadder" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="checkBoxFixRotation" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="checkBoxAddUseLandmarkAngles" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="32767" attributes="0"/>
                       </Group>
                   </Group>
@@ -502,6 +505,15 @@
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxLadderActionPerformed"/>
+                  </Events>
+                </Component>
+                <Component class="javax.swing.JCheckBox" name="checkBoxAddUseLandmarkAngles">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Add UseLandmarkAngles"/>
+                    <Property name="toolTipText" type="java.lang.String" value="&lt;html&gt;&#xa;Adds &quot;UseLandmarkAngles 1&quot; to trigger_teleport entities that have no value set&lt;br&gt;&#xa;and also do not have a landmark specified. Older games do not use this key and&lt;br&gt;&#xa;instead treat it as if the value is 1, except when a landmark is set. Use this to&lt;br&gt;&#xa;ensure consistant behavior when recompiling maps from older games for newer ones.&#xa;&lt;/html&gt;"/>
+                  </Properties>
+                  <Events>
+                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxAddUseLandmarkAnglesActionPerformed"/>
                   </Events>
                 </Component>
               </SubComponents>
@@ -566,7 +578,7 @@
                       <Component id="checkBoxFixCubemapTex" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="checkBoxFixToolTex" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="90" max="32767" attributes="0"/>
+                      <EmptySpace pref="113" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -693,7 +705,7 @@
                           <Component id="labelSourceFormat" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="comboBoxSourceFormat" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace pref="76" max="32767" attributes="0"/>
+                      <EmptySpace pref="99" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
@@ -711,7 +711,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
         });
 
         checkBoxAddUseLandmarkAngles.setText("Add UseLandmarkAngles");
-        checkBoxAddUseLandmarkAngles.setToolTipText("<html>\nAdds \"UseLandmarkAngles 1\" to trigger_teleport entities that have no value set<br>\nand also do not have a landmark specified. Older games do not use this key and<br>\ninstead treat it as if the value is 1, except when a landmark is set. Use this to<br>\nensure consistant behavior when recompiling maps from older games for newer ones.\n</html>");
+        checkBoxAddUseLandmarkAngles.setToolTipText("<html>\nAdds \"UseLandmarkAngles 1\" to trigger_teleport entities that have no value set<br>\nand also do not have a landmark specified. Older games do not use this key and<br>\ninstead treat it as if the value is 1, except when a landmark is set. Use this to<br>\nensure consistent behavior when recompiling maps from older games for newer ones.\n</html>");
         checkBoxAddUseLandmarkAngles.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 checkBoxAddUseLandmarkAnglesActionPerformed(evt);

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
@@ -144,7 +144,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
         checkBoxFixRotation.setSelected(config.fixEntityRot);
         checkBoxLoadLumpFile.setSelected(config.loadLumpFiles);
         checkBoxOccluder.setSelected(config.writeOccluders);
-        checkBoxLadder.setSelected(config.writeLadders);
+        checkBoxLadder.setSelected(config.writeLaddersAsEntities);
         checkBoxOverlay.setSelected(config.writeOverlays);
         checkBoxPropStatic.setSelected(config.writeStaticProps);
         checkBoxVisgroups.setSelected(config.writeVisgroups);
@@ -701,6 +701,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
         });
 
         checkBoxLadder.setText("func_ladder");
+        checkBoxLadder.setToolTipText("<html>Writes ladders as func_ladder entities.<br>Do not use if you intend to recompile for CSGO!</html>");
         checkBoxLadder.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 checkBoxLadderActionPerformed(evt);
@@ -1005,7 +1006,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
     }// </editor-fold>//GEN-END:initComponents
 
     private void checkBoxLadderActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkBoxLadderActionPerformed
-        config.writeLadders = checkBoxLadder.isSelected();
+        config.writeLaddersAsEntities = checkBoxLadder.isSelected();
     }//GEN-LAST:event_checkBoxLadderActionPerformed
 
     private void checkBoxEnableEntitiesActionPerformed(java.awt.event.ActionEvent evt) {                                                       

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
@@ -145,6 +145,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
         checkBoxLoadLumpFile.setSelected(config.loadLumpFiles);
         checkBoxOccluder.setSelected(config.writeOccluders);
         checkBoxLadder.setSelected(config.writeLaddersAsEntities);
+        checkBoxAddUseLandmarkAngles.setSelected(config.addUseLandmarkAngles);
         checkBoxOverlay.setSelected(config.writeOverlays);
         checkBoxPropStatic.setSelected(config.writeStaticProps);
         checkBoxVisgroups.setSelected(config.writeVisgroups);
@@ -429,6 +430,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
         checkBoxOccluder = new javax.swing.JCheckBox();
         checkBoxFixRotation = new javax.swing.JCheckBox();
         checkBoxLadder = new javax.swing.JCheckBox();
+        checkBoxAddUseLandmarkAngles = new javax.swing.JCheckBox();
         checkBoxEnableEntities = new javax.swing.JCheckBox();
         panelTextures = new javax.swing.JPanel();
         labelFaceTex = new javax.swing.JLabel();
@@ -502,7 +504,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
             .addGroup(panelFilesLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(panelFilesLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(scrollFiles, javax.swing.GroupLayout.DEFAULT_SIZE, 158, Short.MAX_VALUE)
+                    .addComponent(scrollFiles, javax.swing.GroupLayout.DEFAULT_SIZE, 181, Short.MAX_VALUE)
                     .addGroup(panelFilesLayout.createSequentialGroup()
                         .addComponent(buttonAdd)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -617,7 +619,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
                 .addGroup(panelWorldBrushesLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(checkBoxDisp)
                     .addComponent(panelBrushMode, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(41, Short.MAX_VALUE))
+                .addContainerGap(64, Short.MAX_VALUE))
         );
 
         tabbedPaneOptions.addTab("World", panelWorldBrushes);
@@ -708,6 +710,14 @@ public class BspSourceFrame extends javax.swing.JFrame {
             }
         });
 
+        checkBoxAddUseLandmarkAngles.setText("Add UseLandmarkAngles");
+        checkBoxAddUseLandmarkAngles.setToolTipText("<html>\nAdds \"UseLandmarkAngles 1\" to trigger_teleport entities that have no value set<br>\nand also do not have a landmark specified. Older games do not use this key and<br>\ninstead treat it as if the value is 1, except when a landmark is set. Use this to<br>\nensure consistant behavior when recompiling maps from older games for newer ones.\n</html>");
+        checkBoxAddUseLandmarkAngles.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                checkBoxAddUseLandmarkAnglesActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout panelBrushEntsLayout = new javax.swing.GroupLayout(panelBrushEnts);
         panelBrushEnts.setLayout(panelBrushEntsLayout);
         panelBrushEntsLayout.setHorizontalGroup(
@@ -719,7 +729,8 @@ public class BspSourceFrame extends javax.swing.JFrame {
                     .addComponent(checkBoxAreaportal)
                     .addComponent(checkBoxOccluder)
                     .addComponent(checkBoxFixRotation)
-                    .addComponent(checkBoxLadder))
+                    .addComponent(checkBoxLadder)
+                    .addComponent(checkBoxAddUseLandmarkAngles))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         panelBrushEntsLayout.setVerticalGroup(
@@ -735,6 +746,8 @@ public class BspSourceFrame extends javax.swing.JFrame {
                 .addComponent(checkBoxLadder)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(checkBoxFixRotation)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(checkBoxAddUseLandmarkAngles)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -841,7 +854,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
                 .addComponent(checkBoxFixCubemapTex)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(checkBoxFixToolTex)
-                .addContainerGap(90, Short.MAX_VALUE))
+                .addContainerGap(113, Short.MAX_VALUE))
         );
 
         tabbedPaneOptions.addTab("Textures", panelTextures);
@@ -955,7 +968,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
                 .addGroup(panelOtherLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(labelSourceFormat)
                     .addComponent(comboBoxSourceFormat, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(76, Short.MAX_VALUE))
+                .addContainerGap(99, Short.MAX_VALUE))
         );
 
         tabbedPaneOptions.addTab("Other", panelOther);
@@ -1008,6 +1021,10 @@ public class BspSourceFrame extends javax.swing.JFrame {
     private void checkBoxLadderActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkBoxLadderActionPerformed
         config.writeLaddersAsEntities = checkBoxLadder.isSelected();
     }//GEN-LAST:event_checkBoxLadderActionPerformed
+
+    private void checkBoxAddUseLandmarkAnglesActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkBoxAddUseLandmarkAnglesActionPerformed
+        config.addUseLandmarkAngles = checkBoxAddUseLandmarkAngles.isSelected();
+    }//GEN-LAST:event_checkBoxAddUseLandmarkAnglesActionPerformed
 
     private void checkBoxEnableEntitiesActionPerformed(java.awt.event.ActionEvent evt) {                                                       
         config.setWriteEntities(checkBoxEnableEntities.isSelected());
@@ -1200,6 +1217,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
     private javax.swing.ButtonGroup buttonGroupBrushMode;
     private javax.swing.JButton buttonRemove;
     private javax.swing.JButton buttonRemoveAll;
+    private javax.swing.JCheckBox checkBoxAddUseLandmarkAngles;
     private javax.swing.JCheckBox checkBoxAreaportal;
     private javax.swing.JCheckBox checkBoxCameras;
     private javax.swing.JCheckBox checkBoxCubemap;

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
@@ -700,7 +700,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
             }
         });
 
-        checkBoxLadder.setText("func_ladder");
+        checkBoxLadder.setText("Ladders as func_ladder");
         checkBoxLadder.setToolTipText("<html>Writes ladders as func_ladder entities.<br>Do not use if you intend to recompile for CSGO!</html>");
         checkBoxLadder.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {

--- a/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
+++ b/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
@@ -178,9 +178,7 @@ public class BspDecompiler extends ModuleDecompile {
                 entsrc.writeCubemaps();
             }
             
-            if (config.writeLaddersAsEntities) {
-                entsrc.writeLadders();
-            }
+            entsrc.writeLadders();
         }
     }
 }

--- a/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
+++ b/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
@@ -178,7 +178,7 @@ public class BspDecompiler extends ModuleDecompile {
                 entsrc.writeCubemaps();
             }
             
-            if (config.writeLadders) {
+            if (config.writeLaddersAsEntities) {
                 entsrc.writeLadders();
             }
         }

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -747,7 +747,14 @@ public class EntitySource extends ModuleDecompile {
      * Writes all func_ladder entities
      */
     public void writeLadders() {
-        L.info("Writing func_ladders");
+        String ladderClass = "func_detail";
+        
+        if (config.writeLaddersAsEntities) 
+        {
+            ladderClass = "func_ladder";
+        }
+        
+        L.log(Level.INFO, "Writing ladders (as {0})", ladderClass);
 
         for (int i = 0; i < bsp.brushes.size(); i++) {
             DBrush brush = bsp.brushes.get(i);
@@ -759,8 +766,8 @@ public class EntitySource extends ModuleDecompile {
             
             // write brush as func_ladder
             writer.start("entity");
-            writer.put("id", vmfmeta.getUID());
-            writer.put("classname", "func_ladder");
+            writer.put("id", vmfmeta.getUID());            
+            writer.put("classname", ladderClass);
 
             brushsrc.writeBrush(i);
 

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -266,6 +266,16 @@ public class EntitySource extends ModuleDecompile {
                 writer.put(key, value);
             }
             
+            if (className.equals("trigger_teleport") && config.addUseLandmarkAngles) {
+                boolean hasULA = ent.hasKey("UseLandmarkAngles");
+                boolean hasLandmark = ent.getValue("landmark") != null;
+                
+                if (!hasULA && !hasLandmark)
+                {
+                    writer.put("UseLandmarkAngles", "1");
+                }
+            }
+            
             writer.put("classname", className);
 
             // write entity I/O

--- a/src/main/java/info/ata4/bspsrc/modules/geom/BrushSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/geom/BrushSource.java
@@ -161,7 +161,7 @@ public class BrushSource extends ModuleDecompile {
             }
             
             // skip ladders
-            if (config.writeLadders && brush.isLadder()) {
+            if (config.writeLaddersAsEntities && brush.isLadder()) {
                 continue;
             }
             

--- a/src/main/java/info/ata4/bspsrc/modules/geom/BrushSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/geom/BrushSource.java
@@ -161,7 +161,7 @@ public class BrushSource extends ModuleDecompile {
             }
             
             // skip ladders
-            if (config.writeLaddersAsEntities && brush.isLadder()) {
+            if (brush.isLadder()) {
                 continue;
             }
             

--- a/src/main/java/info/ata4/bspsrc/modules/geom/FaceSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/geom/FaceSource.java
@@ -755,6 +755,7 @@ public class FaceSource extends ModuleDecompile {
         
         writer.put("power", di.power);
         writer.put("startposition", di.startPos, 2);
+        writer.put("flags", di.getSurfaceFlags());
         writer.put("elevation", 0);
         writer.put("subdiv", 0);
 

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
@@ -39,6 +39,9 @@ public class TextureBuilder {
     private static EnumSet<SurfaceFlag> SURF_FLAGS_AREAPORTAL = EnumSet.of(SurfaceFlag.SURF_NOLIGHT);
     private static EnumSet<BrushFlag> BRUSH_FLAGS_AREAPORTAL = EnumSet.of(BrushFlag.CONTENTS_AREAPORTAL);
     
+    //not sure how complete this blocklight signature is
+    private static EnumSet<BrushFlag> BRUSH_FLAGS_BLOCKLIGHT = EnumSet.of(BrushFlag.CONTENTS_DETAIL, BrushFlag.CONTENTS_OPAQUE);
+    
     private final BspData bsp;
     private final TextureSource texsrc;
     
@@ -134,9 +137,19 @@ public class TextureBuilder {
         }
         
         Set<BrushFlag> brushFlags = brush.contents;
-        
+                
         // fix clip textures
-        if (surfFlags.equals(SURF_FLAGS_CLIP)) {
+        if (surfFlags.equals(SURF_FLAGS_CLIP)) {            
+            if (brush.isLadder())
+            {
+                return ToolTexture.INVISLADDER;
+            }
+            
+            if (brush.contents.equals(BRUSH_FLAGS_BLOCKLIGHT))
+            {
+                return ToolTexture.BLOCKLIGHT;
+            }
+            
             if (brush.isDetail()) {
                 // clip
                 if (brush.isPlayerClip() && brush.isNpcClip()) {


### PR DESCRIPTION
Displacement surface flags are not saved in the decompiled vmf, which means such displacements are always collidable regardless of their status in the input bsp. I used the following snippet from `hl2sdk-csgo\public\builddisp.cpp` to determine how to extract the flags, and I've confirmed it works but I have no idea if this differs between games.
```cpp
if ( ( minTess & 0x80000000 ) != 0 )
{
	// If the high bit is set, this represents FLAGS (SURF_NOPHYSICS_COLL, etc.) flags.
	int nFlags = minTess;
	nFlags &= ~0x80000000;
	GetSurface()->SetFlags( nFlags );
}
```