### PR TITLE
Support displacement surface flags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>bspsrc</artifactId>
     <groupId>info.ata4.bspsrc</groupId>
     <packaging>jar</packaging>
-    <version>1.3.23-SNAPSHOT</version>
+    <version>1.3.24-SNAPSHOT</version>
     <description>A Source engine map decompile</description>
     <url>https://github.com/ata4/bspsource</url>
   

--- a/src/main/java/info/ata4/bsplib/struct/DDispInfo.java
+++ b/src/main/java/info/ata4/bsplib/struct/DDispInfo.java
@@ -96,4 +96,12 @@ public class DDispInfo implements DStruct {
     public boolean hasMultiBlend() {
         return ((minTess + DDispInfo.DISP_INFO_FLAG_MAGIC) & DDispInfo.DISP_INFO_FLAG_HAS_MULTIBLEND) != 0;
     }
+
+    public int getSurfaceFlags() {
+        if ((minTess & DDispInfo.DISP_INFO_FLAG_MAGIC) != 0) {
+            return minTess & ~DDispInfo.DISP_INFO_FLAG_MAGIC;
+        } else {
+            return 0;
+        }
+    }
 }

--- a/src/main/java/info/ata4/bspsrc/BspSource.java
+++ b/src/main/java/info/ata4/bspsrc/BspSource.java
@@ -35,7 +35,7 @@ public class BspSource implements Runnable {
     
     private static final Logger L = LogUtils.getLogger();
 
-    public static final String VERSION = "1.3.23";
+    public static final String VERSION = "1.3.24";
     
     private final BspSourceConfig config;
     

--- a/src/main/java/info/ata4/bspsrc/modules/geom/FaceSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/geom/FaceSource.java
@@ -755,6 +755,7 @@ public class FaceSource extends ModuleDecompile {
         
         writer.put("power", di.power);
         writer.put("startposition", di.startPos, 2);
+        writer.put("flags", di.getSurfaceFlags());
         writer.put("elevation", 0);
         writer.put("subdiv", 0);
 


### PR DESCRIPTION
(Recreated request #35 but from a separate branch as I should have originally)

Displacement surface flags are not saved in the decompiled vmf, which means such displacements are always collidable regardless of their status in the input bsp. I used the following snippet from `hl2sdk-csgo\public\builddisp.cpp` to determine how to extract the flags.
```cpp
if ( ( minTess & 0x80000000 ) != 0 )
{
	// If the high bit is set, this represents FLAGS (SURF_NOPHYSICS_COLL, etc.) flags.
	int nFlags = minTess;
	nFlags &= ~0x80000000;
	GetSurface()->SetFlags( nFlags );
}
```