### PR TITLE
Made 'extract embedded files' selected by default

### DIFF
--- a/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
+++ b/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
@@ -43,7 +43,7 @@ public final class BspSourceConfig implements Serializable {
     public boolean loadLumpFiles = true;
     public boolean nullOutput = false;
     public boolean skipProt = false;
-    public boolean unpackEmbedded = false;
+    public boolean unpackEmbedded = true;
     public float backfaceDepth = 1;
     public int maxCubemapSides = 8;
     public int maxOverlaySides = 64;


### PR DESCRIPTION
I think that most people want to extract the files inside the bsp while decompiling. It makes sense that this options should be activated by default. 