### PR TITLE
Fixed grenade clips from cs:go converting into nodraws

### DIFF
--- a/src/main/java/info/ata4/bsplib/struct/DBrush.java
+++ b/src/main/java/info/ata4/bsplib/struct/DBrush.java
@@ -71,6 +71,11 @@ public class DBrush implements DStruct {
         return contents.contains(BrushFlag.CONTENTS_WINDOW);
     }
 
+    //TODO: CSGO only?
+    public boolean isGrenadeClip() {
+        return contents.contains(BrushFlag.CONTENTS_CURRENT_90);
+    }
+
     @Override
     public int getSize() {
         return 12;

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
@@ -9,20 +9,16 @@
  */
 package info.ata4.bspsrc.modules.texture;
 
-import info.ata4.bsplib.app.SourceAppID;
-import info.ata4.bsplib.struct.BrushFlag;
-import info.ata4.bsplib.struct.BspData;
-import info.ata4.bsplib.struct.DBrush;
-import info.ata4.bsplib.struct.DBrushSide;
-import info.ata4.bsplib.struct.DTexData;
-import info.ata4.bsplib.struct.DTexInfo;
-import info.ata4.bsplib.struct.SurfaceFlag;
+import info.ata4.bsplib.struct.*;
 import info.ata4.bsplib.vector.Vector3f;
 import info.ata4.log.LogUtils;
+
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static info.ata4.bsplib.app.SourceAppID.COUNTER_STRIKE_GO;
 
 /**
  * A builder to create Texture objects.
@@ -42,6 +38,8 @@ public class TextureBuilder {
     private final BspData bsp;
     private final TextureSource texsrc;
 
+    private final int appID;
+
     private Texture texture;
     private Vector3f origin;
     private Vector3f angles;
@@ -54,9 +52,10 @@ public class TextureBuilder {
     private int ibrush = -1;
     private int ibrushside = -1;
 
-    TextureBuilder(TextureSource texsrc, BspData bsp) {
+    TextureBuilder(TextureSource texsrc, BspData bsp, int appID) {
         this.texsrc = texsrc;
         this.bsp = bsp;
+        this.appID = appID;
     }
 
     public Texture build() {
@@ -156,6 +155,11 @@ public class TextureBuilder {
                 // block line of sight
                 if (brush.isBlockLos()) {
                     return ToolTexture.BLOCKLOS;
+                }
+
+                //Todo: CSGO only?
+                if (brush.isGrenadeClip() && appID == COUNTER_STRIKE_GO) {
+                    return ToolTexture.GRENADECLIP;
                 }
             }
 

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
@@ -13,12 +13,13 @@ package info.ata4.bspsrc.modules.texture;
 import info.ata4.bsplib.BspFileReader;
 import info.ata4.bspsrc.modules.ModuleRead;
 import info.ata4.log.LogUtils;
+import org.apache.commons.io.FilenameUtils;
+
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.io.FilenameUtils;
 
 /**
  * Decompiling module to create Texture objects from texture data and to fix
@@ -142,7 +143,7 @@ public class TextureSource extends ModuleRead {
     }
 
     public TextureBuilder getTextureBuilder() {
-        return new TextureBuilder(this, bsp);
+        return new TextureBuilder(this, bsp, bspFile.getSourceApp().getAppID());
     }
 
     public void addBrushSideID(int itexname, int side) {

--- a/src/main/java/info/ata4/bspsrc/modules/texture/ToolTexture.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/ToolTexture.java
@@ -30,6 +30,7 @@ public final class ToolTexture {
     public static final String CLIP = "tools/toolsclip";
     public static final String PLAYERCLIP = "tools/toolsplayerclip";
     public static final String NPCCLIP = "tools/toolsnpcclip";
+    public static final String GRENADECLIP = "tools/toolsgrenadeclip";
     public static final String AREAPORTAL = "tools/toolsareaportal";
     public static final String BLOCKLIGHT = "tools/toolsblocklight";
     public static final String BLOCKBULLETS = "tools/toolsblockbullets";


### PR DESCRIPTION
I've implemented a simple fix that allows grenade clips to be properly identified again.
However, the engine seems to be reusing an older, no longer in use, brush flag to mark them. This would probablycause problems in older engines which still use this brush flag.
Because of this and that I hadn't more games to test it on, i only activated this fix for Cs:Go.