### PR TITLE
Fixed 'Render in Fast Reflections' of static props not being set correctly for CSGO

### DIFF
--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -35,6 +35,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static info.ata4.bsplib.app.SourceAppID.COUNTER_STRIKE_GO;
+
 /**
  * Decompiling module to write point and brush entities converted from various lumps.
  * 
@@ -605,8 +607,13 @@ public class EntitySource extends ModuleDecompile {
             writer.put("solid", pst4.solid);
             writer.put("model", bsp.staticPropName.get(pst4.propType));
 
+            //Csgo no longer uses the screenspacefade flag for 'Screen space fade' but for 'Render in fastreflection'
             if (pst4.hasScreenSpaceFadeInPixels()) {
-                writer.put("screenspacefade", pst4.hasScreenSpaceFadeInPixels());
+                if (bspFile.getSourceApp().getAppID() == COUNTER_STRIKE_GO) {
+                    writer.put("drawinfastreflection", pst4.hasScreenSpaceFadeInPixels());
+                } else {
+                    writer.put("screenspacefade", pst4.hasScreenSpaceFadeInPixels());
+                }
             }
 
             // store coordinates and targetname of the lighing origin for later


### PR DESCRIPTION
Static props don't have their 'Render in Fast Reflections' set, due to no implementation for it.
In CSGO the option uses the 'SCREEN_SPACE_FADE' flag, which was previously used for a now obsolete option, Screen Space Fade.
I've changed that this flag is used for 'Render in Fast Reflections' instead of 'Screen Space Fade' if the game is CSGO.