### PR TITLE
Refactor FileDrop Constructors

### DIFF
--- a/src/main/java/info/ata4/bspinfo/gui/BspInfoFrame.java
+++ b/src/main/java/info/ata4/bspinfo/gui/BspInfoFrame.java
@@ -98,17 +98,11 @@ public class BspInfoFrame extends javax.swing.JFrame {
         initComponentsCustom();
 
         // init file dropper
-        fdrop = new FileDrop(this, new FileDrop.Listener() {
-
-            @Override
-            public void filesDropped(File[] files) {
-                java.io.FileFilter filter = new BspFileFilter();
-
-                if (filter.accept(files[0])) {
-                    loadFile(files[0]);
-                }
-            }
-        });
+        fdrop = new FileDrop(this, files -> {
+		    if (new BspFileFilter().accept(files[0])) {
+		        loadFile(files[0]);
+		    }
+		});
 
         // add dialog log handler
         L.addHandler(new DialogHandler(this));

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
@@ -79,26 +79,22 @@ public class BspSourceFrame extends javax.swing.JFrame {
         reset();
 
         // init file dropper
-        fdrop = new FileDrop(listFiles, new FileDrop.Listener() {
+        fdrop = new FileDrop(listFiles, files -> {
+		    java.io.FileFilter filter = new BspFileFilter();
 
-            @Override
-            public void filesDropped(File[] files) {
-                java.io.FileFilter filter = new BspFileFilter();
+		    for (File file : files) {
+		        if (file.isDirectory()) {
+		            File[] subFiles = file.listFiles(filter);
+		            for (File subFile : subFiles) {
+		                listFilesModel.addElement(new BspFileEntry(subFile));
+		            }
+		        } else if (filter.accept(file)) {
+		            listFilesModel.addElement(new BspFileEntry(file));
+		        }
+		    }
 
-                for (File file : files) {
-                    if (file.isDirectory()) {
-                        File[] subFiles = file.listFiles(filter);
-                        for (File subFile : subFiles) {
-                            listFilesModel.addElement(new BspFileEntry(subFile));
-                        }
-                    } else if (filter.accept(file)) {
-                        listFilesModel.addElement(new BspFileEntry(file));
-                    }
-                }
-
-                buttonDecompile.setEnabled(!listFilesModel.isEmpty());
-            }
-        });
+		    buttonDecompile.setEnabled(!listFilesModel.isEmpty());
+		});
     }
 
     public ComboBoxModel getFaceTextureModel() {

--- a/src/main/java/info/ata4/util/gui/FileDrop.java
+++ b/src/main/java/info/ata4/util/gui/FileDrop.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.EventObject;
 import java.util.List;
 import java.util.TooManyListenersException;
+import java.util.function.*;
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.border.Border;
@@ -79,7 +80,7 @@ public class FileDrop {
      */
     public FileDrop(
             final Component c,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
         this(null, // Logging stream
                 c, // Drop target
                 BorderFactory.createMatteBorder(2, 2, 2, 2, defaultBorderColor), // Drag border
@@ -100,7 +101,7 @@ public class FileDrop {
     public FileDrop(
             final Component c,
             final boolean recursive,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
         this(null, // Logging stream
                 c, // Drop target
                 BorderFactory.createMatteBorder(2, 2, 2, 2, defaultBorderColor), // Drag border
@@ -124,7 +125,7 @@ public class FileDrop {
     public FileDrop(
             final PrintStream out,
             final Component c,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
         this(out, // Logging stream
                 c, // Drop target
                 BorderFactory.createMatteBorder(2, 2, 2, 2, defaultBorderColor),
@@ -153,7 +154,7 @@ public class FileDrop {
             final PrintStream out,
             final Component c,
             final boolean recursive,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
         this(out, // Logging stream
                 c, // Drop target
                 BorderFactory.createMatteBorder(2, 2, 2, 2, defaultBorderColor), // Drag border
@@ -172,7 +173,7 @@ public class FileDrop {
     public FileDrop(
             final Component c,
             final Border dragBorder,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
         this(
                 null, // Logging stream
                 c, // Drop target
@@ -196,7 +197,7 @@ public class FileDrop {
             final Component c,
             final Border dragBorder,
             final boolean recursive,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
         this(
                 null,
                 c,
@@ -222,7 +223,7 @@ public class FileDrop {
             final PrintStream out,
             final Component c,
             final Border dragBorder,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
         this(
                 out, // Logging stream
                 c, // Drop target
@@ -250,7 +251,7 @@ public class FileDrop {
             final Component c,
             final Border dragBorder,
             final boolean recursive,
-            final Listener listener) {
+            final Consumer<File[]> listener) {
 
         if (supportsDnD()) {   // Make a drop listener
             dropListener = new DropTargetListener() {
@@ -309,7 +310,7 @@ public class FileDrop {
 
                             // Alert listener to drop.
                             if (listener != null) {
-                                listener.filesDropped(files);
+                                listener.accept(files);
                             }
 
                             // Mark that drop is completed.
@@ -334,7 +335,7 @@ public class FileDrop {
                                     BufferedReader br = new BufferedReader(reader);
 
                                     if (listener != null) {
-                                        listener.filesDropped(createFileArray(br, out));
+                                        listener.accept(createFileArray(br, out));
                                     }
 
                                     // Mark that drop is completed.
@@ -576,33 +577,6 @@ public class FileDrop {
             return false;
         }
     }   // end remove
-
-    /* ********  I N N E R   I N T E R F A C E   L I S T E N E R  ******** */
-    /**
-     * Implement this inner interface to listen for when files are dropped. For example
-     * your class declaration may begin like this:
-     * <code><pre>
-     *      public class MyClass implements FileDrop.Listener
-     *      ...
-     *      public void filesDropped( java.io.File[] files )
-     *      {
-     *          ...
-     *      }   // end filesDropped
-     *      ...
-     * </pre></code>
-     *
-     * @since 1.1
-     */
-    public static interface Listener {
-
-        /**
-         * This method is called when files have been successfully dropped.
-         *
-         * @param files An array of <tt>File</tt>s that were dropped.
-         * @since 1.0
-         */
-        public abstract void filesDropped(File[] files);
-    }   // end inner-interface Listener
 
 
     /* ********  I N N E R   C L A S S  ******** */


### PR DESCRIPTION
Refactor FileDrop constructors to use Consumer<File[]> instead of inner interface. Remove the unused interface, replace existing anonymus implementations with lambdas.