### PR TITLE
Refactor 'Manual mode' of AreaportalMapper and general fixes/cleanup to OccluderMapper

### DIFF
--- a/src/main/java/info/ata4/bsplib/util/VectorUtil.java
+++ b/src/main/java/info/ata4/bsplib/util/VectorUtil.java
@@ -1,0 +1,76 @@
+package info.ata4.bsplib.util;
+
+import info.ata4.bsplib.vector.Vector2f;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class VectorUtil
+{
+	//https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
+	public static boolean isInsideConvexPolygon(Vector2f p, List<Vector2f> polygon)
+	{
+		return IntStream.range(0, polygon.size())
+				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
+				.filter(edge -> (edge[0].y > p.y) != (edge[1].y > p.y) && (p.x < (edge[1].x - edge[0].x) * (p.y - edge[0].y) / (edge[1].y - edge[0].y) + edge[0].x))
+				.limit(2)
+				.count() % 2 == 1;
+	}
+
+
+	public static Set<Vector2f> getPolygonIntersections(List<Vector2f> polygon1, List<Vector2f> polygon2)
+	{
+		return IntStream.range(0, polygon1.size())
+				.mapToObj(i -> new Vector2f[]{polygon1.get(i), polygon1.get((i + 1) % polygon1.size())})
+				.flatMap(edge -> IntStream.range(0, polygon2.size())
+						.mapToObj(i -> new Vector2f[]{polygon2.get(i), polygon2.get((i + 1) % polygon2.size())})
+						.map(edge2 -> lineIntersection(edge[0], edge[1], edge2[0], edge2[1])))
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.collect(Collectors.toSet());
+	}
+
+	//https://stackoverflow.com/a/565282
+	public static Optional<Vector2f> lineIntersection(Vector2f origin1, Vector2f end1, Vector2f origin2, Vector2f end2)
+	{
+		Vector2f cmP = origin2.sub(origin1);
+		Vector2f r = end1.sub(origin1);
+		Vector2f s = end2.sub(origin2);
+
+		float CmPxr = cmP.x * r.y - cmP.y * r.x;
+		float CmPxs = cmP.x * s.y - cmP.y * s.x;
+		float rxs = r.x * s.y - r.y * s.x;
+
+		if (rxs == 0f)
+			return Optional.empty(); // Lines are parallel.
+
+		float rxsr = 1f / rxs;
+		float t = CmPxs * rxsr;
+		float u = CmPxr * rxsr;
+
+		if ((t >= 0f) && (t <= 1f) && (u >= 0f) && (u <= 1f))
+			return Optional.of(origin1.add(end1.sub(origin1).scalar(t)));
+		else
+			return Optional.empty();
+	}
+
+	public static double polygonArea(List<Vector2f> polygon)
+	{
+		return IntStream.range(0, polygon.size())
+				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
+				.mapToDouble(edge -> (edge[0].x + edge[1].x) * (edge[0].y - edge[1].y))
+				.sum() / 2;
+	}
+
+	public static List<Vector2f> orderVertices(Collection<Vector2f> vertices)
+	{
+		Vector2f midPoint = vertices.stream()
+				.reduce((vertex1, vertex2) -> vertex1.add(vertex2).scalar(0.5f))
+				.orElse(new Vector2f(0, 0));
+
+		return vertices.stream()
+				.sorted(Comparator.comparingDouble(vertex -> Math.atan2(vertex.x - midPoint.x, vertex.y - midPoint.y)))
+				.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/info/ata4/bsplib/util/VectorUtil.java
+++ b/src/main/java/info/ata4/bsplib/util/VectorUtil.java
@@ -6,11 +6,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public class VectorUtil
-{
+public class VectorUtil {
+
 	//https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
-	public static boolean isInsideConvexPolygon(Vector2f p, List<Vector2f> polygon)
-	{
+	public static boolean isInsideConvexPolygon(Vector2f p, List<Vector2f> polygon) {
 		return IntStream.range(0, polygon.size())
 				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
 				.filter(edge -> (edge[0].y > p.y) != (edge[1].y > p.y) && (p.x < (edge[1].x - edge[0].x) * (p.y - edge[0].y) / (edge[1].y - edge[0].y) + edge[0].x))
@@ -19,8 +18,7 @@ public class VectorUtil
 	}
 
 
-	public static Set<Vector2f> getPolygonIntersections(List<Vector2f> polygon1, List<Vector2f> polygon2)
-	{
+	public static Set<Vector2f> getPolygonIntersections(List<Vector2f> polygon1, List<Vector2f> polygon2) {
 		return IntStream.range(0, polygon1.size())
 				.mapToObj(i -> new Vector2f[]{polygon1.get(i), polygon1.get((i + 1) % polygon1.size())})
 				.flatMap(edge -> IntStream.range(0, polygon2.size())
@@ -32,8 +30,7 @@ public class VectorUtil
 	}
 
 	//https://stackoverflow.com/a/565282
-	public static Optional<Vector2f> lineIntersection(Vector2f origin1, Vector2f end1, Vector2f origin2, Vector2f end2)
-	{
+	public static Optional<Vector2f> lineIntersection(Vector2f origin1, Vector2f end1, Vector2f origin2, Vector2f end2) {
 		Vector2f cmP = origin2.sub(origin1);
 		Vector2f r = end1.sub(origin1);
 		Vector2f s = end2.sub(origin2);
@@ -55,16 +52,14 @@ public class VectorUtil
 			return Optional.empty();
 	}
 
-	public static double polygonArea(List<Vector2f> polygon)
-	{
+	public static double polygonArea(List<Vector2f> polygon) {
 		return IntStream.range(0, polygon.size())
 				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
 				.mapToDouble(edge -> (edge[0].x + edge[1].x) * (edge[0].y - edge[1].y))
 				.sum() / 2;
 	}
 
-	public static List<Vector2f> orderVertices(Collection<Vector2f> vertices)
-	{
+	public static List<Vector2f> orderVertices(Collection<Vector2f> vertices) {
 		Vector2f midPoint = vertices.stream()
 				.reduce((vertex1, vertex2) -> vertex1.add(vertex2).scalar(0.5f))
 				.orElse(new Vector2f(0, 0));

--- a/src/main/java/info/ata4/bsplib/vector/Vector2f.java
+++ b/src/main/java/info/ata4/bsplib/vector/Vector2f.java
@@ -1,0 +1,254 @@
+package info.ata4.bsplib.vector;
+
+import info.ata4.io.DataReader;
+import info.ata4.io.DataWriter;
+
+import java.io.IOException;
+
+public class Vector2f extends VectorXf
+{
+	public static Vector2f read(DataReader in) throws IOException
+	{
+		float x = in.readFloat();
+		float y = in.readFloat();
+		return new Vector2f(x, y);
+	}
+
+	public static void write(DataWriter out, Vector2f vec) throws IOException {
+		out.writeFloat(vec.x);
+		out.writeFloat(vec.y);
+	}
+
+	// frequently used pre-defined vectors
+	public static final Vector2f NULL = new Vector2f(0, 0);
+	public static final Vector2f MAX_VALUE = new Vector2f(Float.MAX_VALUE, Float.MAX_VALUE);
+	public static final Vector2f MIN_VALUE = MAX_VALUE.scalar(-1); // don't use Float.MIN_VALUE here
+
+	// vector values
+	public final float x;
+	public final float y;
+
+	/**
+	 * Replicating contructor
+	 * Constructs new Vector2f by copying an existing Vector2f
+	 *
+	 * @param v The Vector2f to copy
+	 */
+	public Vector2f(Vector2f v) {
+		this(v.x, v.y);
+	}
+
+	/**
+	 * Constructs a new Vector3f using the values out of an array.
+	 * The array must have a size of at least 2.
+	 *
+	 * @param v float array
+	 */
+	public Vector2f(float[] v) {
+		this(v[0], v[1]);
+	}
+
+	/**
+	 * Constructs a new Vector2f from x and y components
+	 *
+	 * @param x the vector x component
+	 * @param y the vector y component
+	 */
+	public Vector2f(float x, float y) {
+		super(2);
+		this.x = x;
+		this.y = y;
+	}
+
+	/**
+	 * Returns the value of the n'th component.
+	 *
+	 * @param index component index
+	 * @return component value
+	 */
+	@Override
+	public float get(int index) {
+		switch (index) {
+			case 0:
+				return this.x;
+			case 1:
+				return this.y;
+			default:
+				return 0;
+		}
+	}
+
+	/**
+	 * Set the value of the n'th component.
+	 *
+	 * @param index component index
+	 * @param value new component value
+	 * @return vector with new value
+	 */
+	@Override
+	public Vector2f set(int index, float value) {
+		switch (index) {
+			case 0:
+				return new Vector2f(value, y);
+			case 1:
+				return new Vector2f(x, value);
+			default:
+				return this;
+		}
+	}
+
+	/**
+	 * Vector dot product: this . that
+	 *
+	 * @param that the Vector2f to take dot product with
+	 * @return the dot product of the two vectors
+	 */
+	public float dot(Vector2f that) {
+		return this.x * that.x + this.y * that.y;
+	}
+
+	/**
+	 * Vector normalisation: ^this
+	 *
+	 * @return the normalised vector
+	 */
+	public Vector2f normalize() {
+		float len = length();
+		float rx = x / len;
+		float ry = y / len;
+
+		return new Vector2f(rx, ry);
+	}
+
+	/**
+	 * Vector addition: this + that
+	 *
+	 * @param that The vector to add
+	 * @return The sum of the two vectors
+	 */
+	public Vector2f add(Vector2f that) {
+		float rx = this.x + that.x;
+		float ry = this.y + that.y;
+
+		return new Vector2f(rx, ry);
+	}
+
+	/**
+	 * Vector subtraction: this - that
+	 *
+	 * @param that The vector to subtract
+	 * @return The difference of the two vectors
+	 */
+	public Vector2f sub(Vector2f that) {
+		float rx = this.x - that.x;
+		float ry = this.y - that.y;
+
+		return new Vector2f(rx, ry);
+	}
+
+	/**
+	 * Snap vector to nearest value: round(this / value) * value
+	 *
+	 * @param value snap value
+	 * @return This vector snapped to the nearest values of 'value'
+	 */
+	public Vector2f snap(float value) {
+		float rx = Math.round(x / value) * value;
+		float ry = Math.round(y / value) * value;
+
+		return new Vector2f(rx, ry);
+	}
+
+	/**
+	 * Calculate the length of this vector
+	 *
+	 * @return length of this vector
+	 */
+	public float length() {
+		return (float) Math.sqrt(Math.pow(this.x, 2) + Math.pow(this.y, 2));
+	}
+
+	/**
+	 * Performs a scalar multiplication on this vector: this * mul
+	 *
+	 * @param mul multiplicator
+	 * @return scalar multiplied vector
+	 */
+	public Vector2f scalar(float mul) {
+		float rx = this.x * mul;
+		float ry = this.y * mul;
+
+		return new Vector2f(rx, ry);
+	}
+
+	/**
+	 * Performs a scalar multiplication on this vector: this * that
+	 *
+	 * @param that multiplicator vector
+	 * @return scalar multiplied vector
+	 */
+	public Vector2f scalar(Vector2f that) {
+		float rx = this.x * that.x;
+		float ry = this.y * that.y;
+
+		return new Vector2f(rx, ry);
+	}
+
+	/**
+	 * Rotates the vector.
+	 *
+	 * @param angle angle rotation in degrees
+	 * @return rotated vector
+	 */
+	public Vector2f rotate(float angle) {
+		// normalize angle
+		angle %= 360;
+
+		// special cases
+		if (angle == 0)
+			return this;
+		if (angle == 90)
+			return new Vector2f(-y, x);
+		if (angle == 180)
+			return new Vector2f(-x, -y);
+		if (angle == 270)
+			return new Vector2f(y, -x);
+
+		// convert degrees to radians
+		double radians = Math.toRadians(angle);
+
+		double r = Math.hypot(x, y);
+		double theta = Math.atan2(y, x);
+
+		double rx = r * Math.cos(theta + radians);
+		double ry = r * Math.sin(theta + radians);
+
+		return new Vector2f((float) rx, (float) ry);
+	}
+
+	/**
+	 * Returns the minima between this vector and another vector.
+	 *
+	 * @param that other vector to compare
+	 * @return minima of this and that vector
+	 */
+	public Vector2f min(Vector2f that) {
+		float rx = Math.min(this.x, that.x);
+		float ry = Math.min(this.y, that.y);
+
+		return new Vector2f(rx, ry);
+	}
+
+	/**
+	 * Returns the maxima between this vector and another vector.
+	 *
+	 * @param that other vector to compare
+	 * @return maxima of this and that vector
+	 */
+	public Vector2f max(Vector2f that) {
+		float rx = Math.max(this.x, that.x);
+		float ry = Math.max(this.y, that.y);
+
+		return new Vector2f(rx, ry);
+	}
+}

--- a/src/main/java/info/ata4/bsplib/vector/Vector2f.java
+++ b/src/main/java/info/ata4/bsplib/vector/Vector2f.java
@@ -5,10 +5,9 @@ import info.ata4.io.DataWriter;
 
 import java.io.IOException;
 
-public class Vector2f extends VectorXf
-{
-	public static Vector2f read(DataReader in) throws IOException
-	{
+public class Vector2f extends VectorXf {
+
+	public static Vector2f read(DataReader in) throws IOException {
 		float x = in.readFloat();
 		float y = in.readFloat();
 		return new Vector2f(x, y);

--- a/src/main/java/info/ata4/bsplib/vector/Vector3f.java
+++ b/src/main/java/info/ata4/bsplib/vector/Vector3f.java
@@ -308,6 +308,11 @@ public final class Vector3f extends VectorXf {
         return new Vector3f(rx, ry, rz);
     }
 
+    public Vector2f to2D(Vector3f origin, Vector3f axis1, Vector3f axis2)
+    {
+        return new Vector2f(axis1.dot(this.sub(origin)), axis2.dot(this.sub(origin)));
+    }
+
     /**
      * Private helper class for rotation
      */

--- a/src/main/java/info/ata4/bsplib/vector/Vector3f.java
+++ b/src/main/java/info/ata4/bsplib/vector/Vector3f.java
@@ -308,7 +308,7 @@ public final class Vector3f extends VectorXf {
         return new Vector3f(rx, ry, rz);
     }
 
-    public Vector2f to2D(Vector3f origin, Vector3f axis1, Vector3f axis2)
+    public Vector2f getAsPointOnPlane(Vector3f origin, Vector3f axis1, Vector3f axis2)
     {
         return new Vector2f(axis1.dot(this.sub(origin)), axis2.dot(this.sub(origin)));
     }

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
@@ -475,7 +475,7 @@
                     <Property name="text" type="java.lang.String" value="func_areaportal/_window"/>
                   </Properties>
                   <Events>
-                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxAreaportalActionPerformed"/>
+                    <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="checkBoxAreaportalStateChanged"/>
                   </Events>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="checkBoxOccluder">
@@ -483,7 +483,7 @@
                     <Property name="text" type="java.lang.String" value="func_occluder"/>
                   </Properties>
                   <Events>
-                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxOccluderActionPerformed"/>
+                    <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="checkBoxOccluderStateChanged"/>
                   </Events>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="checkBoxFixRotation">
@@ -565,9 +565,6 @@
                   <Dimension value="[135, 68]"/>
                 </Property>
               </Properties>
-              <AccessibilityProperties>
-                <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="Areaportal"/>
-              </AccessibilityProperties>
 
               <Layout>
                 <DimensionLayout dim="0">
@@ -594,7 +591,7 @@
                     <Property name="actionCommand" type="java.lang.String" value="forceManualMapping"/>
                   </Properties>
                   <Events>
-                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxApChangeMMActionPerformed"/>
+                    <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="checkBoxApChangeMMStateChanged"/>
                   </Events>
                 </Component>
                 <Component class="javax.swing.JComboBox" name="comboBoxApMapping">
@@ -607,6 +604,7 @@
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="comboBoxApMappingActionPerformed"/>
                   </Events>
                   <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="comboBoxApMapping.setEnabled(checkBoxApChangeMM.isSelected());"/>
                     <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;AreaportalMapper.ApMappingMode&gt;"/>
                   </AuxValues>
                 </Component>
@@ -650,7 +648,7 @@
                     <Property name="text" type="java.lang.String" value="Force mapping"/>
                   </Properties>
                   <Events>
-                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="checkBoxOccChangeMMActionPerformed"/>
+                    <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="checkBoxOccChangeMMStateChanged"/>
                   </Events>
                 </Component>
                 <Component class="javax.swing.JComboBox" name="comboBoxOccMapping">
@@ -663,6 +661,7 @@
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="comboBoxOccMappingActionPerformed"/>
                   </Events>
                   <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="comboBoxOccMapping.setEnabled(checkBoxOccChangeMM.isSelected());"/>
                     <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;OccluderMapper.OccMappingMode&gt;"/>
                   </AuxValues>
                 </Component>

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
@@ -693,16 +693,16 @@ public class BspSourceFrame extends javax.swing.JFrame {
         });
 
         checkBoxAreaportal.setText("func_areaportal/_window");
-        checkBoxAreaportal.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                checkBoxAreaportalActionPerformed(evt);
+        checkBoxAreaportal.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                checkBoxAreaportalStateChanged(evt);
             }
         });
 
         checkBoxOccluder.setText("func_occluder");
-        checkBoxOccluder.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                checkBoxOccluderActionPerformed(evt);
+        checkBoxOccluder.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                checkBoxOccluderStateChanged(evt);
             }
         });
 
@@ -795,13 +795,14 @@ public class BspSourceFrame extends javax.swing.JFrame {
         checkBoxApChangeMM.setText("Force mapping");
         checkBoxApChangeMM.setToolTipText("This forces the mapping of areaportal to brushes to be made manual. Only check this if you're getting trouble with the default mapping methode");
         checkBoxApChangeMM.setActionCommand("forceManualMapping");
-        checkBoxApChangeMM.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                checkBoxApChangeMMActionPerformed(evt);
+        checkBoxApChangeMM.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                checkBoxApChangeMMStateChanged(evt);
             }
         });
 
         comboBoxApMapping.setModel(new DefaultComboBoxModel<>(AreaportalMapper.ApMappingMode.values()));
+        comboBoxApMapping.setEnabled(checkBoxApChangeMM.isSelected());
         comboBoxApMapping.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 comboBoxApMappingActionPerformed(evt);
@@ -827,13 +828,14 @@ public class BspSourceFrame extends javax.swing.JFrame {
         jpOccluderMapping.setPreferredSize(new java.awt.Dimension(135, 46));
 
         checkBoxOccChangeMM.setText("Force mapping");
-        checkBoxOccChangeMM.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                checkBoxOccChangeMMActionPerformed(evt);
+        checkBoxOccChangeMM.addChangeListener(new javax.swing.event.ChangeListener() {
+            public void stateChanged(javax.swing.event.ChangeEvent evt) {
+                checkBoxOccChangeMMStateChanged(evt);
             }
         });
 
         comboBoxOccMapping.setModel(new DefaultComboBoxModel<>(OccluderMapper.OccMappingMode.values()));
+        comboBoxOccMapping.setEnabled(checkBoxOccChangeMM.isSelected());
         comboBoxOccMapping.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 comboBoxOccMappingActionPerformed(evt);
@@ -877,8 +879,6 @@ public class BspSourceFrame extends javax.swing.JFrame {
                     .addComponent(jpAreaportalMapping, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap(121, Short.MAX_VALUE))
         );
-
-        jpAreaportalMapping.getAccessibleContext().setAccessibleName("Areaportal");
 
         tabbedPaneOptions.addTab("Entity mapping", jpEntityMapping);
 
@@ -1118,10 +1118,6 @@ public class BspSourceFrame extends javax.swing.JFrame {
         config.writeLadders = checkBoxLadder.isSelected();
     }//GEN-LAST:event_checkBoxLadderActionPerformed
 
-    private void checkBoxApChangeMMActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkBoxApChangeMMActionPerformed
-        config.apForceMapping = checkBoxApChangeMM.isSelected();
-    }//GEN-LAST:event_checkBoxApChangeMMActionPerformed
-
     private void comboBoxApMappingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_comboBoxApMappingActionPerformed
         config.apMappingMode = (AreaportalMapper.ApMappingMode) comboBoxApMapping.getSelectedItem();
     }//GEN-LAST:event_comboBoxApMappingActionPerformed
@@ -1130,9 +1126,35 @@ public class BspSourceFrame extends javax.swing.JFrame {
         config.occMappingMode = (OccluderMapper.OccMappingMode) comboBoxOccMapping.getSelectedItem();
     }//GEN-LAST:event_comboBoxOccMappingActionPerformed
 
-    private void checkBoxOccChangeMMActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_checkBoxOccChangeMMActionPerformed
+    private void checkBoxAreaportalStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxAreaportalStateChanged
+        config.writeAreaportals = checkBoxAreaportal.isSelected();
+        checkBoxApChangeMM.setEnabled(checkBoxAreaportal.isSelected());
+        
+        if (!checkBoxAreaportal.isSelected()) {
+            checkBoxApChangeMM.setSelected(false);
+            config.apForceMapping = false;
+        }
+    }//GEN-LAST:event_checkBoxAreaportalStateChanged
+
+    private void checkBoxOccluderStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxOccluderStateChanged
+        config.writeOccluders = checkBoxOccluder.isSelected();
+        checkBoxOccChangeMM.setEnabled(checkBoxOccluder.isSelected());
+        
+        if (!checkBoxOccluder.isSelected()) {
+            checkBoxOccChangeMM.setSelected(false);
+            config.occForceMapping = false;
+        }
+    }//GEN-LAST:event_checkBoxOccluderStateChanged
+
+    private void checkBoxApChangeMMStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxApChangeMMStateChanged
+        config.apForceMapping = checkBoxApChangeMM.isSelected();
+        comboBoxApMapping.setEnabled(checkBoxApChangeMM.isSelected());
+    }//GEN-LAST:event_checkBoxApChangeMMStateChanged
+
+    private void checkBoxOccChangeMMStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxOccChangeMMStateChanged
         config.occForceMapping = checkBoxOccChangeMM.isSelected();
-    }//GEN-LAST:event_checkBoxOccChangeMMActionPerformed
+        comboBoxOccMapping.setEnabled(checkBoxOccChangeMM.isSelected());
+    }//GEN-LAST:event_checkBoxOccChangeMMStateChanged
 
     private void checkBoxEnableEntitiesActionPerformed(java.awt.event.ActionEvent evt) {                                                       
         config.setWriteEntities(checkBoxEnableEntities.isSelected());
@@ -1141,29 +1163,7 @@ public class BspSourceFrame extends javax.swing.JFrame {
 
     private void checkBoxPropStaticActionPerformed(java.awt.event.ActionEvent evt) {                                                   
         config.writeStaticProps = checkBoxPropStatic.isSelected();
-    }                                                  
-
-    private void checkBoxAreaportalActionPerformed(java.awt.event.ActionEvent evt) {                                                   
-        config.writeAreaportals = checkBoxAreaportal.isSelected();
-        checkBoxApChangeMM.setEnabled(checkBoxAreaportal.isSelected());
-        comboBoxApMapping.setEnabled(checkBoxAreaportal.isSelected());
-        
-        if (!checkBoxAreaportal.isSelected()) {
-            checkBoxApChangeMM.setSelected(false);
-            config.apForceMapping = false;
-        }
-    }                                                  
-
-    private void checkBoxOccluderActionPerformed(java.awt.event.ActionEvent evt) {                                                 
-        config.writeOccluders = checkBoxOccluder.isSelected();
-        checkBoxOccChangeMM.setEnabled(checkBoxOccluder.isSelected());
-        comboBoxOccMapping.setEnabled(checkBoxOccluder.isSelected());
-        
-        if (!checkBoxOccluder.isSelected()) {
-            checkBoxOccChangeMM.setSelected(false);
-            config.occForceMapping = false;
-        }
-    }                                                
+    }                                               
 
     private void checkBoxDetailActionPerformed(java.awt.event.ActionEvent evt) {                                               
         config.writeDetails = checkBoxDetail.isSelected();

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -308,8 +308,7 @@ public class EntitySource extends ModuleDecompile {
                 if (isOccluder && occluderNum != -1) {
                     if (config.brushMode == BrushMode.BRUSHPLANES && occBrushesMap.containsKey(occluderNum)) {
                         for (int brushId: occBrushesMap.get(occluderNum)) {
-                            if (brushId != -1)
-                                brushsrc.writeBrush(brushId);
+                            brushsrc.writeBrush(brushId);
                         }
                         visgroups.add("Reallocated occluders");
                     } else {

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
@@ -184,7 +184,7 @@ public class TextureBuilder {
 
         // fix occluder textures
         String textureName = bsp.texnames.get(texture.getData().texname);
-        if (brush.isFlaggedAsOccluder() && textureName.equalsIgnoreCase(ToolTexture.AREAPORTAL))
+        if (brush.isFlaggedAsOccluder() && !textureName.equalsIgnoreCase(ToolTexture.NODRAW))
             return ToolTexture.OCCLUDER;
 
         return null;

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -105,8 +105,7 @@ public class AreaportalMapper {
      *
      * @return A {@code Map} where the keys represent areaportal ids and the values brush ids
      */
-    private Map<Integer, Integer> manualMapping()
-    {
+    private Map<Integer, Integer> manualMapping() {
         Map<DBrush, Map<AreaportalHelper, Double>> brushProbMapping = areaportalBrushes.stream()
                 .collect(Collectors.toMap(dBrush -> dBrush, this::areaportalBrushProb));
 
@@ -122,8 +121,7 @@ public class AreaportalMapper {
 
         // Final brush mapping. Key represent areaportal ids, values represent index in bsp.brushes
         HashMap<Integer, Integer> brushMapping = new HashMap<>();
-        while (!brushProbMapping.isEmpty())
-        {
+        while (!brushProbMapping.isEmpty()) {
             TreeMap<DBrush, Map<AreaportalHelper, Double>> mappingQueue = new TreeMap<>(Comparator.comparingInt(areaportalBrushes::indexOf));
 
             // Get all brush mappings that only have one available areaportal to map to. These can be safely mapped as they don't create conflicts with other areaportal brushes (At least they shouldn't theoretically)
@@ -131,8 +129,7 @@ public class AreaportalMapper {
                     .filter(dBrushMapEntry -> dBrushMapEntry.getValue().size() == 1)
                     .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
 
-            if (mappingQueue.isEmpty())
-            {
+            if (mappingQueue.isEmpty()) {
                 // We ended up with only brushes that can't be mapped distinctively so we guess one to map by using the mapping with the highest probability
                 brushProbMapping.entrySet().stream()
                         .max(Comparator.comparingDouble(entry -> entry.getValue().entrySet().stream()
@@ -143,13 +140,11 @@ public class AreaportalMapper {
             }
 
             // Now mapped those brushes we selected earlier
-            for (Entry<DBrush, Map<AreaportalHelper, Double>> entry : mappingQueue.entrySet())
-            {
+            for (Entry<DBrush, Map<AreaportalHelper, Double>> entry : mappingQueue.entrySet()) {
                 DBrush dBrush = entry.getKey();
                 Map<AreaportalHelper, Double> apHelperProbMap = entry.getValue();
 
-                if (!apHelperProbMap.isEmpty())
-                {
+                if (!apHelperProbMap.isEmpty()) {
                     AreaportalHelper apHelper = apHelperProbMap.keySet().iterator().next();
                     int portalID = apHelper.portalID.first();
 
@@ -181,8 +176,7 @@ public class AreaportalMapper {
      * @param dBrush An areaportal brush
      * @return A {@code Map} with <b>copys</b> of {@link AreaportalHelper}'s as keys and and a percantage(0 < p <= 1) as likelihood
      */
-    private Map<AreaportalHelper, Double> areaportalBrushProb(DBrush dBrush)
-    {
+    private Map<AreaportalHelper, Double> areaportalBrushProb(DBrush dBrush) {
         return IntStream.range(0, dBrush.numside)
                 .boxed()
                 .flatMap(side -> areaportalHelpers.stream()
@@ -198,8 +192,7 @@ public class AreaportalMapper {
      * @param brushSideWinding a winding representing the brush side
      * @return A probability in form of a double ranging from 0 to 1
      */
-    private double areaportalBrushSideProb(AreaportalHelper areaportalHelper, Winding brushSideWinding)
-    {
+    private double areaportalBrushSideProb(AreaportalHelper areaportalHelper, Winding brushSideWinding) {
         Winding apWinding = new Winding(areaportalHelper.vertices);
 
         // Test if apWinding and brushSideWinding share the same plane
@@ -270,8 +263,7 @@ public class AreaportalMapper {
      *
      * @return A {@code Map} where the keys represent portal ids and values the brush ids
      */
-    public Map<Integer,Integer> getApBrushMapping()
-    {
+    public Map<Integer,Integer> getApBrushMapping() {
         if (!config.writeAreaportals)
             return Collections.emptyMap();
 
@@ -317,16 +309,13 @@ public class AreaportalMapper {
         public TreeSet<Integer> portalID = new TreeSet<>();         //All areaportal entities assigned to this helper. All areaportals are sorted by their portalID!
         public Vector3f[] vertices;
 
-        public AreaportalHelper()
-        {
-        }
+        public AreaportalHelper() {}
 
-        public AreaportalHelper(AreaportalHelper apHelper)
-        {
+        public AreaportalHelper(AreaportalHelper apHelper) {
             portalID.addAll(apHelper.portalID);
             vertices = new Vector3f[apHelper.vertices.length];
-            for (int i = 0; i < vertices.length; i++)
-            {
+
+            for (int i = 0; i < vertices.length; i++) {
                 vertices[i] = new Vector3f(apHelper.vertices[i]);
             }
         }

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -65,8 +65,7 @@ public class AreaportalMapper {
 
             // Do we already have a 'AreaportalHelper' that represents this areaportal?
             Optional<AreaportalHelper> matchingApHelper = areaportalHelpers.stream()
-                    .filter(apHelper -> IntStream.range(0, apHelper.vertices.length)
-                            .allMatch(i -> apHelper.vertices[i].equals(bsp.clipPortalVerts.get(dAreaportal.firstClipPortalVert + i).point)))
+                    .filter(apHelper -> apHelper.winding.matches(WindingFactory.fromAreaportal(bsp, dAreaportal)))
                     .findAny();
 
             // If there is no AreaportalHelper that represents this portal, we create one
@@ -75,9 +74,7 @@ public class AreaportalMapper {
                 matchingApHelper.get().portalID.add((int) dAreaportal.portalKey);
             } else {
                 AreaportalHelper areaportalHelper = new AreaportalHelper();
-                areaportalHelper.vertices = bsp.clipPortalVerts.subList(dAreaportal.firstClipPortalVert, dAreaportal.firstClipPortalVert + dAreaportal.clipPortalVerts).stream()
-                        .map(dVertex -> dVertex.point)
-                        .toArray(Vector3f[]::new);
+                areaportalHelper.winding = WindingFactory.fromAreaportal(bsp, dAreaportal);
                 areaportalHelper.portalID.add((int) dAreaportal.portalKey);
                 areaportalHelpers.add(areaportalHelper);
             }
@@ -193,7 +190,7 @@ public class AreaportalMapper {
      * @return A probability in form of a double ranging from 0 to 1
      */
     private double areaportalBrushSideProb(AreaportalHelper areaportalHelper, Winding brushSideWinding) {
-        Winding apWinding = new Winding(areaportalHelper.vertices);
+        Winding apWinding = areaportalHelper.winding;
 
         // Test if apWinding and brushSideWinding share the same plane
         if (!apWinding.isInSamePlane(brushSideWinding))
@@ -307,17 +304,13 @@ public class AreaportalMapper {
     private class AreaportalHelper {
 
         public TreeSet<Integer> portalID = new TreeSet<>();         //All areaportal entities assigned to this helper. All areaportals are sorted by their portalID!
-        public Vector3f[] vertices;
+        public Winding winding;
 
         public AreaportalHelper() {}
 
         public AreaportalHelper(AreaportalHelper apHelper) {
             portalID.addAll(apHelper.portalID);
-            vertices = new Vector3f[apHelper.vertices.length];
-
-            for (int i = 0; i < vertices.length; i++) {
-                vertices[i] = new Vector3f(apHelper.vertices[i]);
-            }
+            winding = apHelper.winding;
         }
     }
 }

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -106,12 +106,12 @@ public class AreaportalMapper {
         Map<DBrush, Map<AreaportalHelper, Double>> brushProbMapping = areaportalBrushes.stream()
                 .collect(Collectors.toMap(dBrush -> dBrush, this::areaportalBrushProb));
 
-        Map<Integer, Set<Integer>> debug = brushProbMapping.entrySet().stream()
-                .map(entry -> new AbstractMap.SimpleEntry<Integer, Set<Integer>>(areaportalBrushes.indexOf(entry.getKey()), entry.getValue().entrySet().stream()
-                        .max(Comparator.comparingDouble(Entry::getValue))
-                        .map(apEntry -> apEntry.getKey().portalID)
-                        .orElse(null)))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+//        Map<Integer, Set<Integer>> debug = brushProbMapping.entrySet().stream()
+//                .map(entry -> new AbstractMap.SimpleEntry<Integer, Set<Integer>>(areaportalBrushes.indexOf(entry.getKey()), entry.getValue().entrySet().stream()
+//                        .max(Comparator.comparingDouble(Entry::getValue))
+//                        .map(apEntry -> apEntry.getKey().portalID)
+//                        .orElse(null)))
+//                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         // Remove every brush entry if it doesn't have areaportals mapped to it. (Not sure if this could actually happen here)
         brushProbMapping.entrySet().removeIf(dBrushMapEntry -> dBrushMapEntry.getValue().isEmpty());
@@ -147,8 +147,7 @@ public class AreaportalMapper {
 
                     // When we map a brush to the specific areaportal id, we need to make sure no other brush is mapped to it as well. -> Iterate over every brush mapping and remove the areaportal id if present
                     brushProbMapping.entrySet().stream()
-                            .flatMap(dBrushMapEntry -> dBrushMapEntry.getValue().entrySet().stream()
-                                    .map(Entry::getKey))
+                            .flatMap(dBrushMapEntry -> dBrushMapEntry.getValue().keySet().stream())
                             .forEach(areaportalHelper -> areaportalHelper.portalID.removeIf(integer -> integer == portalID));
 
                     // This could cause Areaportalhelpers to be empty (of portal ids), so we remove every entry with those
@@ -177,7 +176,7 @@ public class AreaportalMapper {
         return IntStream.range(0, dBrush.numside)
                 .boxed()
                 .flatMap(side -> areaportalHelpers.stream()
-                        .map(apHelper -> new AbstractMap.SimpleEntry<AreaportalHelper, Double>(new AreaportalHelper(apHelper), areaportalBrushSideProb(apHelper, WindingFactory.fromSide(bsp, dBrush, side))))
+                        .map(apHelper -> new AbstractMap.SimpleEntry<>(new AreaportalHelper(apHelper), areaportalBrushSideProb(apHelper, WindingFactory.fromSide(bsp, dBrush, side))))
                         .filter(entry -> entry.getValue() != 0))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
@@ -207,11 +206,11 @@ public class AreaportalMapper {
 
         //Map 3d coordinates of windings to 2d (2d coordinates on the plane they lie on)
         List<Vector2f> apPolygon = apWinding.stream()
-                .map(vertex -> vertex.to2D(origin, axis1, axis2))
+                .map(vertex -> vertex.getAsPointOnPlane(origin, axis1, axis2))
                 .collect(Collectors.toList());
 
         List<Vector2f> brushSidePolygon = brushSideWinding.stream()
-                .map(vertex -> vertex.to2D(origin, axis1, axis2))
+                .map(vertex -> vertex.getAsPointOnPlane(origin, axis1, axis2))
                 .collect(Collectors.toList());
 
         Set<Vector2f> intersectingVertices = new HashSet<>();

--- a/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
@@ -106,8 +106,7 @@ public class OccluderMapper {
      * @param dOccluderData occluder to find brushes for
      * @return a Integer list of brush indexes
      */
-    private List<Integer> mapOccluder(DOccluderData dOccluderData)
-    {
+    private List<Integer> mapOccluder(DOccluderData dOccluderData) {
         return bsp.occluderPolyDatas.subList(dOccluderData.firstpoly, dOccluderData.firstpoly + dOccluderData.polycount).stream()
                 .map(dOccluderPolyData -> potentialOccluderBrushes.stream()
                         .filter(dBrush -> bsp.brushSides.subList(dBrush.fstside, dBrush.fstside + dBrush.numside).stream()
@@ -126,8 +125,7 @@ public class OccluderMapper {
      * @param dBrushSide the brush side
      * @return true if the specified occluder face matches with the specified brush side, false otherwise
      */
-    private boolean occFacesMatchesBrushFace(DOccluderPolyData dOccluderPolyData, DBrush dBrush, DBrushSide dBrushSide)
-    {
+    private boolean occFacesMatchesBrushFace(DOccluderPolyData dOccluderPolyData, DBrush dBrush, DBrushSide dBrushSide) {
         Winding w = WindingFactory.fromSide(bsp, dBrush, dBrushSide);
 
         // If the amount of vertices are unequal we know the cant be identical

--- a/src/main/java/info/ata4/bspsrc/util/Winding.java
+++ b/src/main/java/info/ata4/bspsrc/util/Winding.java
@@ -14,6 +14,7 @@ import info.ata4.bsplib.struct.*;
 import info.ata4.bsplib.vector.Vector3f;
 import java.util.*;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Winding utility class.
@@ -451,6 +452,38 @@ public class Winding implements List<Vector3f> {
         }
 
         return new AABB(mins, maxs);
+    }
+
+
+    /**
+     * Checks if this winding shares the same plane with the other one
+     *
+     * @param w the other winding
+     * @return true if both windings share the same plane otherwise false
+     */
+    public boolean isInSamePlane(Winding w)
+    {
+        // A wingind with only 2 vertices can't build a plane
+        if (size() < 3 || w.size() < 3)
+            return false;
+
+        Vector3f[] plane = buildPlane();
+        Vector3f vec1 = plane[1].sub(plane[0]);
+        Vector3f vec2 = plane[2].sub(plane[0]);
+        Vector3f normal = vec2.cross(vec1);
+        float dist = normal.normalize().dot(new Vector3f(0f, 0f, 0f).sub(plane[0]));
+
+        Vector3f[] wPlane = w.buildPlane();
+        Vector3f wVec1 = wPlane[1].sub(wPlane[0]);
+        Vector3f wVec2 = wPlane[2].sub(wPlane[0]);
+        Vector3f wNormal = wVec2.cross(wVec1);
+        float wDist = wNormal.normalize().dot(new Vector3f(0f, 0f, 0f).sub(wPlane[0]));
+
+        Vector3f cross = wNormal.normalize().cross(normal.normalize());
+        if (cross.dot(cross) < 0.001)                                           //TODO: I have no idea how you would actually mathematically compute the error margine, so im just using a guessed one here
+            return Math.abs(Math.abs(dist) - Math.abs(wDist)) < EPS_DEGEN;      //TODO: Maybe remove 'EPS_DEGEN'. I have no idea if this is needed here or how you should even use it
+        else
+            return false;
     }
 
     /**

--- a/src/main/java/info/ata4/bspsrc/util/WindingFactory.java
+++ b/src/main/java/info/ata4/bspsrc/util/WindingFactory.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Factory methods for winding objects.
@@ -163,16 +164,9 @@ public class WindingFactory {
             return areaportalCache.get(ap);
         }
 
-        List<Vector3f> verts = new ArrayList<>();
-
-        //int clipPortalVerts = Math.min(4, ap.clipPortalVerts); //TODO: Find reason for this as it doesn't really make sense (Maybe older engines?)
-        int clipPortalVerts = ap.clipPortalVerts;
-        for (int i = 0; i < clipPortalVerts; i++) {
-            int pvi = ap.firstClipPortalVert + i;
-            verts.add(bsp.clipPortalVerts.get(pvi).point);
-        }
-
-        Winding w = new Winding(verts);
+        Winding w = bsp.clipPortalVerts.subList(ap.firstClipPortalVert, ap.firstClipPortalVert + ap.clipPortalVerts).stream()
+                .map(dVertex -> dVertex.point)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Winding::new));
 
         areaportalCache.put(ap, w);
 

--- a/test/maps/test_areaportals.vmf
+++ b/test/maps/test_areaportals.vmf
@@ -1,8 +1,8 @@
 versioninfo
 {
 	"editorversion" "400"
-	"editorbuild" "7958"
-	"mapversion" "6"
+	"editorbuild" "8075"
+	"mapversion" "10"
 	"formatversion" "100"
 	"prefab" "0"
 }
@@ -20,7 +20,7 @@ viewsettings
 world
 {
 	"id" "1"
-	"mapversion" "6"
+	"mapversion" "10"
 	"classname" "worldspawn"
 	"detailmaterial" "detail/detailsprites"
 	"detailvbsp" "detail.vbsp"
@@ -1705,7 +1705,7 @@ world
 		side
 		{
 			"id" "1"
-			"plane" "(-480 0 256) (-480 1184 256) (992 1184 256)"
+			"plane" "(-480 1184 256) (992 1184 256) (992 0 256)"
 			"material" "DEV/DEV_MEASUREGENERIC01B"
 			"uaxis" "[1 0 0 0] 0.25"
 			"vaxis" "[0 -1 0 0] 0.25"
@@ -1716,7 +1716,7 @@ world
 		side
 		{
 			"id" "2"
-			"plane" "(-480 1184 224) (-480 1184 256) (-480 0 256)"
+			"plane" "(-480 1184 256) (-480 0 256) (-480 0 224)"
 			"material" "DEV/DEV_MEASUREGENERIC01B"
 			"uaxis" "[0 1 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -1727,7 +1727,7 @@ world
 		side
 		{
 			"id" "3"
-			"plane" "(992 0 224) (992 0 256) (992 1184 256)"
+			"plane" "(992 0 256) (992 1184 256) (992 1184 224)"
 			"material" "DEV/DEV_MEASUREGENERIC01B"
 			"uaxis" "[0 1 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -1738,7 +1738,7 @@ world
 		side
 		{
 			"id" "4"
-			"plane" "(992 1184 224) (992 1184 256) (-480 1184 256)"
+			"plane" "(992 1184 256) (-480 1184 256) (-480 1184 224)"
 			"material" "DEV/DEV_MEASUREGENERIC01B"
 			"uaxis" "[1 0 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -1749,7 +1749,7 @@ world
 		side
 		{
 			"id" "5"
-			"plane" "(-480 0 224) (-480 0 256) (992 0 256)"
+			"plane" "(-480 0 256) (992 0 256) (992 0 224)"
 			"material" "DEV/DEV_MEASUREGENERIC01B"
 			"uaxis" "[1 0 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -1760,7 +1760,7 @@ world
 		side
 		{
 			"id" "6"
-			"plane" "(-480 1184 224) (-480 0 224) (992 0 224)"
+			"plane" "(-480 0 224) (992 0 224) (992 1184 224)"
 			"material" "DEV/DEV_MEASUREGENERIC01B"
 			"uaxis" "[1 0 0 0] 0.25"
 			"vaxis" "[0 -1 0 0] 0.25"
@@ -7915,7 +7915,7 @@ entity
 		side
 		{
 			"id" "622"
-			"plane" "(928 128 160) (928 128 32) (864 64 32)"
+			"plane" "(928 128 32) (864 64 32) (864 64 160)"
 			"material" "TOOLS/TOOLSAREAPORTAL"
 			"uaxis" "[1 0 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -7926,7 +7926,7 @@ entity
 		side
 		{
 			"id" "621"
-			"plane" "(912 144 32) (848 80 32) (864 64 32)"
+			"plane" "(848 80 32) (864 64 32) (928 128 32)"
 			"material" "TOOLS/TOOLSAREAPORTAL"
 			"uaxis" "[0 -1 0 0] 0.25"
 			"vaxis" "[-1 0 0 0] 0.25"
@@ -7937,7 +7937,7 @@ entity
 		side
 		{
 			"id" "620"
-			"plane" "(848 80 160) (848 80 32) (912 144 32)"
+			"plane" "(848 80 32) (912 144 32) (912 144 160)"
 			"material" "TOOLS/TOOLSAREAPORTAL"
 			"uaxis" "[1 0 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -7948,7 +7948,7 @@ entity
 		side
 		{
 			"id" "619"
-			"plane" "(864 64 160) (864 64 32) (848 80 32)"
+			"plane" "(864 64 32) (848 80 32) (848 80 160)"
 			"material" "TOOLS/TOOLSAREAPORTAL"
 			"uaxis" "[0 1 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -7959,7 +7959,7 @@ entity
 		side
 		{
 			"id" "618"
-			"plane" "(912 144 160) (912 144 32) (928 128 32)"
+			"plane" "(912 144 32) (928 128 32) (928 128 160)"
 			"material" "TOOLS/TOOLSAREAPORTAL"
 			"uaxis" "[0 1 0 0] 0.25"
 			"vaxis" "[0 0 -1 0] 0.25"
@@ -7970,7 +7970,7 @@ entity
 		side
 		{
 			"id" "617"
-			"plane" "(928 128 160) (864 64 160) (848 80 160)"
+			"plane" "(864 64 160) (848 80 160) (912 144 160)"
 			"material" "TOOLS/TOOLSAREAPORTAL"
 			"uaxis" "[1 0 0 0] 0.25"
 			"vaxis" "[0 -1 0 0] 0.25"
@@ -8013,7 +8013,12 @@ entity
 }
 cameras
 {
-	"activecamera" "-1"
+	"activecamera" "0"
+	camera
+	{
+		"position" "[758.81 1511.43 759.688]"
+		"look" "[758.635 1510.71 759.018]"
+	}
 }
 cordons
 {


### PR DESCRIPTION
The previous method for manually mapping areaportals was still very heavily relying on the ordering of brushes/areaportals. I've implemented a new algorithm, which now calculates probabilities to get correct mappings.

At its core it's very simple. Every areaportal brush is compared against all available areaportals. For each we calculate the probability that the brush represents it. The probability is based on the surface area they 'share'. So for example, if the brush doesn't even touch the areaportal, the probability would obviously be 0. If they do touch, we get the intersection area of the brushside and the areaportal and calculate it's surface area. The final probability is determined by dividing this surface area with the surface area of the areaportal.

Other than that I did some syntax changes to the class OccluderMapper to make it more readable.
Changes are tested on Cs:go.