### PR TITLE
Enabled blocklight fix for every game

### DIFF
--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
@@ -157,7 +157,7 @@ public class TextureBuilder {
                     return ToolTexture.BLOCKLOS;
                 }
 
-                // block light, tested in csgo, portal 2, garrysmod
+                // block light, tested in csgo, portal 2, garrysmod, black mesa - 03.09.2019
                 if (brush.isOpaque()) {
                     return ToolTexture.BLOCKLIGHT;
                 }

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
@@ -157,6 +157,11 @@ public class TextureBuilder {
                     return ToolTexture.BLOCKLOS;
                 }
 
+                // block light, tested in csgo, portal 2, garrysmod
+                if (brush.isOpaque()) {
+                    return ToolTexture.BLOCKLIGHT;
+                }
+
                 if (appID == COUNTER_STRIKE_GO) {
                     if (brush.isCurrent90()) {
                         return ToolTexture.CSGO_GRENADECLIP;
@@ -164,11 +169,6 @@ public class TextureBuilder {
 
                     if (brush.isCurrent180()) {
                         return ToolTexture.CSGO_DRONECLIP;
-                    }
-
-                    //Todo: CSGO only?
-                    if (brush.isOpaque()) {
-                        return ToolTexture.BLOCKLIGHT;
                     }
                 }
             }


### PR DESCRIPTION
The blocklight fix, which got previously implemented with https://github.com/ata4/bspsrc/commit/e0ad93effaaff3221021cad195a9b868d75da884, was only enabled for cs:go because it was only tested on this game.
I tested the fix on two additional games, Garrysmod and Portal 2. Both work perfectly fine, so I enabled the fix for every game.
In combination with #48, fixes #44.