### PR TITLE
Fixed IndexOutOfBoundsException when decompiling maps without entity lump

### DIFF
--- a/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
+++ b/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
@@ -56,11 +56,16 @@ public class VmfMeta extends ModuleDecompile {
     public VmfMeta(BspFileReader reader, VmfWriter writer) {
         super(reader, writer);
 
-        worldspawn = bsp.entities.get(0);
+        if (bsp.entities.isEmpty())
+        {
+            L.warning("Couldn't get Worldspawn-entity, because entity list is empty (Probably because map uses external lump files). The map may be missing some information like skybox or detail sprites...");
+        } else {
+            worldspawn = bsp.entities.get(0);
 
-        // check for existing map comment
-        if (worldspawn.getValue("comment") != null) {
-            L.log(Level.INFO, "Map comment: {0}", worldspawn.getValue("comment"));
+            // check for existing map comment
+            if (worldspawn.getValue("comment") != null) {
+                L.log(Level.INFO, "Map comment: {0}", worldspawn.getValue("comment"));
+            }
         }
     }
 
@@ -170,7 +175,8 @@ public class VmfMeta extends ModuleDecompile {
     public void writeWorldHeader() {
         writer.start("world");
         writer.put("id", getUID());
-        writer.put(worldspawn);
+        if (worldspawn != null)
+            writer.put(worldspawn);
 
         // write comment
         if (comment != null) {


### PR DESCRIPTION
I've made a small change to the vmf writing process. It fixes the IndexOutOfBoundsException that was being thrown when trying to decompile maps without an entity lump.

Fixes #53 