### PR TITLE
Add better static prop support for Black Mesa

### DIFF
--- a/src/main/java/info/ata4/bsplib/BspFileReader.java
+++ b/src/main/java/info/ata4/bsplib/BspFileReader.java
@@ -371,6 +371,27 @@ public class BspFileReader {
                         structClass = DStaticPropV11CSGO.class;
                     }
                     break;
+
+                case BLACK_MESA:
+                    // different structures used by Black Mesa
+                    if (sprpver == 10 && propStaticSize == 72) {
+                        structClass = DStaticPropV10.class;
+                    } else if (sprpver == 11) {
+                        if (propStaticSize == 76) {
+                            structClass = DStaticPropV11lite.class;
+                        } else if (propStaticSize == 80) {
+                            structClass = DStaticPropV11.class;
+                        }
+                    }
+                    break;
+
+                default:
+                    // check for "lite" version of V11 struct in case it applies
+                    // to a game other than BM (or BM wasn't detected/selected)
+                    if (sprpver == 11 && propStaticSize == 76) {
+                        structClass = DStaticPropV11lite.class;
+                    }
+                    break;
             }
 
             // get structure class for the static prop lump version if it's not
@@ -396,7 +417,10 @@ public class BspFileReader {
             }
 
             // if the correct class is still unknown at this point, fall back to
-            // a very basic version that should hopefully work in all situations
+            // a very basic version that should hopefully work in most situations
+            // (note: this will not work well if the struct is based on the V10
+            // struct from the Source 2013 or the TF2 Source engine branches,
+            // in which case the flags attribute will contain garbage data)
             int numFillBytes = 0;
             if (structClass == null) {
                 L.log(Level.WARNING, "Falling back to static prop v4");

--- a/src/main/java/info/ata4/bsplib/app/SourceAppID.java
+++ b/src/main/java/info/ata4/bsplib/app/SourceAppID.java
@@ -35,4 +35,5 @@ public class SourceAppID {
     public static final int TITANFALL = -400;
     public static final int TEAM_FORTRESS_2 = 440;
     public static final int COUNTER_STRIKE_GO = 730;
+    public static final int BLACK_MESA = 362890;
 }

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV11.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV11.java
@@ -14,32 +14,31 @@ import info.ata4.io.DataWriter;
 import java.io.IOException;
 
 /**
- * V11 structure found in BM, possibly found in recent Source 2013 games as
- * well.
- *
- * @author Nico Bergemann <barracuda415 at yahoo.de>
+ * V11 structure found in Black Mesa, xengine(cu5) branch and later releases
+ * (introduced with the December 2017 Update.)
+ * 
+ * Possibly found in recent Source 2013 games as well.
  */
-public class DStaticPropV11 extends DStaticPropV10 {
+public class DStaticPropV11 extends DStaticPropV11lite {
 
-    public int unknown1; // usually -1
-    public int unknown2; // usually 0
+    // m_FlagsEx
+    // Additional flags? Purpose and use unknown. Usually 0.
+    public int flagsEx;
 
     @Override
     public int getSize() {
-        return super.getSize() + 8; // 80
+        return super.getSize() + 4; // 80
     }
 
     @Override
     public void read(DataReader in) throws IOException {
         super.read(in);
-        unknown1 = in.readInt();
-        unknown2 = in.readInt();
+        flagsEx = in.readInt();
     }
 
     @Override
     public void write(DataWriter out) throws IOException {
         super.write(out);
-        out.writeInt(unknown1);
-        out.writeInt(unknown2);
-    }
+        out.writeInt(flagsEx);
+   }
 }

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV11lite.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV11lite.java
@@ -1,0 +1,48 @@
+/*
+** 2019 Sep 3
+**
+** The author disclaims copyright to this source code. In place of
+** a legal notice, here is a blessing:
+**    May you do good and not evil.
+**    May you find forgiveness for yourself and forgive others.
+**    May you share freely, never taking more than you give.
+ */
+package info.ata4.bsplib.struct;
+
+import info.ata4.io.DataReader;
+import info.ata4.io.DataWriter;
+import java.io.IOException;
+
+/**
+ * Older V11 structure found in Black Mesa, surface-tension-update(cu3)
+ * and halloween-update(cu4) branches.
+ */
+public class DStaticPropV11lite extends DStaticPropV10 {
+
+    // m_DiffuseModulation
+    // Contains the "rendercolor" and "renderamt" key-values, which set the
+    // fade color (R G B) and fade alpha (A), respectively.
+    // Usually set to 0xffffff as the default values are "255 255 255" for
+    // rendercolor and "255" for renderamt.
+    // It's unclear if these key-values have any practical use.
+    // bm_c2a5g is the only BM stock map where these values have been set to
+    // non-default values for a few props.
+    public Color32 diffuseModulation;
+
+    @Override
+    public int getSize() {
+        return super.getSize() + 4; // 76
+    }
+
+    @Override
+    public void read(DataReader in) throws IOException {
+        super.read(in);
+        diffuseModulation = new Color32(in.readInt());
+    }
+
+    @Override
+    public void write(DataWriter out) throws IOException {
+        super.write(out);
+        out.writeInt(diffuseModulation.rgba);
+   }
+}

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -682,6 +682,17 @@ public class EntitySource extends ModuleDecompile {
                 }
             }
 
+            if (pst instanceof DStaticPropV11lite) {
+                DStaticPropV11lite pst11 = (DStaticPropV11lite) pst;
+                // only write if it's set to anything other than default
+                if (pst11.diffuseModulation.rgba != -1) {
+                    diffMod = pst11.diffuseModulation;
+                    writer.put("rendercolor", String.format("%d %d %d",
+                            diffMod.r, diffMod.g, diffMod.b));
+                    writer.put("renderamt", diffMod.a);
+                }
+            }
+
             if (pst instanceof DStaticPropV11CSGO) {
                 writer.put("uniformscale", ((DStaticPropV11CSGO) pst).uniformScale);
             }


### PR DESCRIPTION
This PR adds better static prop support for Black Mesa across all the different branches/releases of Black Mesa.

I have added a struct class for an older version of the V11 static prop struct, which I named `DStaticPropV11lite`, and changed the `DStaticPropV11` to extend the `DStaticPropV11lite` class.

I have also added support for writing the key-values for the `m_DiffuseModulation` struct field, but only if the values are anything other than the default. The key-values in question are "rendercolor" and "renderamt", which set the fade color (R G B) and fade alpha (A), respectively. These key-values aren't defined in BM's base.fgd. Therefore, I'm not sure if they have any practical use. There is, however, one stock map (bm_c2a5g) that has a few static props where the `m_DiffuseModulation` field is set to a non-default value, although fading appears to be disabled for the props in question.

The current V11 struct has an additional field called `m_FlagsEx`, which purpose and use are unknown. This field is always 0 in all of BM's current stock maps.