### PR TITLE
Update file pattern for Black Mesa in appdb.xml

### DIFF
--- a/src/main/resources/info/ata4/bsplib/app/appdb.xml
+++ b/src/main/resources/info/ata4/bsplib/app/appdb.xml
@@ -1223,7 +1223,7 @@
     </app>
     <app name="Black Mesa" id="362890">
         <version min="20" />
-        <files><![CDATA[^bm_c[0-3]a[0-5][a-i]$]]></files>
+        <files><![CDATA[^(bm_c[0-5]a[0-5][a-i][1]?)|(dm_.*)$]]></files>
         <entities>
             ai_goal_throw_prop
             camera_satellite


### PR DESCRIPTION
Updated the file pattern for Black Mesa in the app database (appdb.xml) to include Xen and multiplayer maps.

**Note:** The RegEx pattern includes maps starting with "dm_", which may possibly affect detection of multiplayer maps for other games.