### PR TITLE
Fix trailing space in brush sides list

### DIFF
--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Decompiling module to write point and brush entities converted from various lumps.
@@ -566,13 +567,9 @@ public class EntitySource extends ModuleDecompile {
             }
 
             // write brush side list
-            StringJoiner sj = new StringJoiner(" ");
-
-            for (Integer side : sides) {
-                sj.add(side.toString());
-            }
-
-            writer.put("sides", sj.toString());
+            writer.put("sides", sides.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(" ")));
 
             if (overlayNames.containsKey(o.id)) {
                 writer.put("targetname", overlayNames.get(o.id));
@@ -727,13 +724,9 @@ public class EntitySource extends ModuleDecompile {
 
                 // write list of brush sides that use this cubemap
                 if (cmSides > 0 && cmSides < config.maxCubemapSides) {
-                    StringJoiner sj = new StringJoiner(" ");
-
-                    for (Integer sideId : sideList) {
-                        sj.add(sideId.toString());
-                    }
-
-                    writer.put("sides", sj.toString());
+                    writer.put("sides", sideList.stream()
+                        .map(String::valueOf)
+                        .collect(Collectors.joining(" ")));
                 }
             }
 

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -566,14 +566,13 @@ public class EntitySource extends ModuleDecompile {
             }
 
             // write brush side list
-            StringBuilder sb = new StringBuilder();
+            StringJoiner sj = new StringJoiner(" ");
 
             for (Integer side : sides) {
-                sb.append(side);
-                sb.append(" ");
+                sj.add(side.toString());
             }
 
-            writer.put("sides", sb.toString());
+            writer.put("sides", sj.toString());
 
             if (overlayNames.containsKey(o.id)) {
                 writer.put("targetname", overlayNames.get(o.id));
@@ -728,17 +727,13 @@ public class EntitySource extends ModuleDecompile {
 
                 // write list of brush sides that use this cubemap
                 if (cmSides > 0 && cmSides < config.maxCubemapSides) {
-                    StringBuilder sb = new StringBuilder();
+                    StringJoiner sj = new StringJoiner(" ");
 
-                    for (int sideId : sideList) {
-                        sb.append(sideId);
-                        sb.append(" ");
+                    for (Integer sideId : sideList) {
+                        sj.add(sideId.toString());
                     }
 
-                    // delete last space
-                    sb.deleteCharAt(sb.length() - 1);
-
-                    writer.put("sides", sb.toString());
+                    writer.put("sides", sj.toString());
                 }
             }
 


### PR DESCRIPTION
This fixes a minor bug where the brush "sides" list in info_overlay entity blocks has a space delimiter before the closing quotation mark.

The change involves employing the use of StringJoiner instead of Stringbuilder for building the brush sides list in the writeOverlays() method in EntitySource. There is a similar loop in the writeCubemaps() method, except here the last space is deleted from the string afterwards. I changed the code here as well for consistency.

Alternatively, we could use Java 8 streams, but I think it performs slightly slower than the for loop with StringJoiner:

```Java
String s = sides.stream()
        .map(String::valueOf)
        .collect(Collectors.joining(" "));
```