### PR TITLE
Clear multiblend flag from disp surface info flags

### DIFF
--- a/src/main/java/info/ata4/bsplib/struct/DDispInfo.java
+++ b/src/main/java/info/ata4/bsplib/struct/DDispInfo.java
@@ -99,7 +99,7 @@ public class DDispInfo implements DStruct {
 
     public int getSurfaceFlags() {
         if ((minTess & DDispInfo.DISP_INFO_FLAG_MAGIC) != 0) {
-            return minTess & ~DDispInfo.DISP_INFO_FLAG_MAGIC;
+            return minTess & ~(DDispInfo.DISP_INFO_FLAG_MAGIC | DDispInfo.DISP_INFO_FLAG_HAS_MULTIBLEND);
         } else {
             return 0;
         }


### PR DESCRIPTION
Support for displacement surface flags was added with PR #39.

However, Black Mesa maps often have the DISP_INFO_FLAG_HAS_MULTIBLEND flag enabled on displacements, which gets written to the displacement flags property along with the surface collision flags. It should be cleared from the return value of getSurfaceFlags() as it is not a surface collision flag. I have confirmed that this flag is not present in the original vmf.

I believe this change is safe to implement for all games, since it either applies to, or has no impact on other games.