### PR TITLE
Occluder/Areaportal fixes

### DIFF
--- a/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
+++ b/src/main/java/info/ata4/bspsrc/BspSourceConfig.java
@@ -12,8 +12,6 @@ package info.ata4.bspsrc;
 
 import info.ata4.bsplib.app.SourceApp;
 import info.ata4.bspsrc.modules.geom.BrushMode;
-import info.ata4.bspsrc.util.AreaportalMapper;
-import info.ata4.bspsrc.util.OccluderMapper;
 import info.ata4.bspsrc.util.SourceFormat;
 import info.ata4.log.LogUtils;
 
@@ -52,16 +50,14 @@ public final class BspSourceConfig implements Serializable {
     public int maxOverlaySides = 64;
     public boolean detailMerge = true;
     public float detailMergeThresh = 1;
-    public boolean apForceMapping = false;
-    public AreaportalMapper.ApMappingMode apMappingMode = AreaportalMapper.ApMappingMode.MANUAL;
+    public boolean apForceManualMapping = false;
     public boolean writeAreaportals = true;
     public boolean writeBrushEntities = true;
     public boolean writeCameras = true;
     public boolean writeCubemaps = true;
     public boolean writeDetails = true;
     public boolean writeDisp = true;
-    public boolean occForceMapping = false;
-    public OccluderMapper.OccMappingMode occMappingMode = OccluderMapper.OccMappingMode.MANUAL;
+    public boolean occForceManualMapping = false;
     public boolean writeOccluders = true;
     public boolean writeOverlays = true;
     public boolean writePointEntities = true;

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.form
@@ -532,10 +532,8 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="jpAreaportalMapping" min="-2" pref="143" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="2" max="-2" attributes="0"/>
-                      <Component id="jpOccluderMapping" min="-2" pref="143" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="jpAreaportalMapping" min="-2" pref="145" max="-2" attributes="0"/>
+                      <EmptySpace pref="155" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -543,11 +541,8 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                          <Component id="jpOccluderMapping" pref="68" max="32767" attributes="0"/>
-                          <Component id="jpAreaportalMapping" max="32767" attributes="0"/>
-                      </Group>
-                      <EmptySpace pref="121" max="32767" attributes="0"/>
+                      <Component id="jpAreaportalMapping" min="-2" pref="69" max="-2" attributes="0"/>
+                      <EmptySpace pref="120" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -557,113 +552,51 @@
               <Properties>
                 <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
                   <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-                    <TitledBorder title="Areaportal"/>
+                    <TitledBorder title="Force Manual Method"/>
                   </Border>
                 </Property>
                 <Property name="name" type="java.lang.String" value="" noResource="true"/>
                 <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                  <Dimension value="[135, 68]"/>
+                  <Dimension value="[135, 48]"/>
                 </Property>
               </Properties>
 
               <Layout>
                 <DimensionLayout dim="0">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="checkBoxApChangeMM" pref="131" max="32767" attributes="0"/>
-                      <Component id="comboBoxApMapping" alignment="0" max="32767" attributes="0"/>
+                      <Component id="checkBoxForceOccMode" max="32767" attributes="0"/>
+                      <Component id="checkBoxForceApMode" alignment="0" pref="133" max="32767" attributes="0"/>
                   </Group>
                 </DimensionLayout>
                 <DimensionLayout dim="1">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="checkBoxApChangeMM" min="-2" max="-2" attributes="0"/>
+                      <Group type="102" attributes="0">
+                          <Component id="checkBoxForceApMode" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="comboBoxApMapping" min="-2" max="-2" attributes="0"/>
+                          <Component id="checkBoxForceOccMode" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
                 </DimensionLayout>
               </Layout>
               <SubComponents>
-                <Component class="javax.swing.JCheckBox" name="checkBoxApChangeMM">
+                <Component class="javax.swing.JCheckBox" name="checkBoxForceApMode">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="Force mapping"/>
-                    <Property name="toolTipText" type="java.lang.String" value="This forces the mapping of areaportal to brushes to be made manual. Only check this if you&apos;re getting trouble with the default mapping methode"/>
+                    <Property name="text" type="java.lang.String" value="Areaportals"/>
+                    <Property name="toolTipText" type="java.lang.String" value="This forces the mapping of areaportals to brushes, to be made manually. Only check this if you&apos;re getting errors with the default mapping method!"/>
                     <Property name="actionCommand" type="java.lang.String" value="forceManualMapping"/>
                   </Properties>
                   <Events>
-                    <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="checkBoxApChangeMMStateChanged"/>
+                    <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="checkBoxForceApModeItemStateChanged"/>
                   </Events>
                 </Component>
-                <Component class="javax.swing.JComboBox" name="comboBoxApMapping">
+                <Component class="javax.swing.JCheckBox" name="checkBoxForceOccMode">
                   <Properties>
-                    <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="new DefaultComboBoxModel&lt;&gt;(AreaportalMapper.ApMappingMode.values())" type="code"/>
-                    </Property>
+                    <Property name="text" type="java.lang.String" value="Occluders"/>
+                    <Property name="toolTipText" type="java.lang.String" value="This forces the mapping of occluders to brushes, to be made manually. Only check this if you&apos;re getting errors with the default mapping method!"/>
                   </Properties>
                   <Events>
-                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="comboBoxApMappingActionPerformed"/>
+                    <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="checkBoxForceOccModeItemStateChanged"/>
                   </Events>
-                  <AuxValues>
-                    <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="comboBoxApMapping.setEnabled(checkBoxApChangeMM.isSelected());"/>
-                    <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;AreaportalMapper.ApMappingMode&gt;"/>
-                  </AuxValues>
-                </Component>
-              </SubComponents>
-            </Container>
-            <Container class="javax.swing.JPanel" name="jpOccluderMapping">
-              <Properties>
-                <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
-                  <Border info="org.netbeans.modules.form.compat2.border.TitledBorderInfo">
-                    <TitledBorder title="Occluder"/>
-                  </Border>
-                </Property>
-                <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                  <Dimension value="[135, 46]"/>
-                </Property>
-              </Properties>
-
-              <Layout>
-                <DimensionLayout dim="0">
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" attributes="0">
-                          <Component id="checkBoxOccChangeMM" pref="125" max="32767" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                      </Group>
-                      <Component id="comboBoxOccMapping" max="32767" attributes="0"/>
-                  </Group>
-                </DimensionLayout>
-                <DimensionLayout dim="1">
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="checkBoxOccChangeMM" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="32767" attributes="0"/>
-                          <Component id="comboBoxOccMapping" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                  </Group>
-                </DimensionLayout>
-              </Layout>
-              <SubComponents>
-                <Component class="javax.swing.JCheckBox" name="checkBoxOccChangeMM">
-                  <Properties>
-                    <Property name="text" type="java.lang.String" value="Force mapping"/>
-                  </Properties>
-                  <Events>
-                    <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="checkBoxOccChangeMMStateChanged"/>
-                  </Events>
-                </Component>
-                <Component class="javax.swing.JComboBox" name="comboBoxOccMapping">
-                  <Properties>
-                    <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="new DefaultComboBoxModel&lt;&gt;(OccluderMapper.OccMappingMode.values())" type="code"/>
-                    </Property>
-                  </Properties>
-                  <Events>
-                    <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="comboBoxOccMappingActionPerformed"/>
-                  </Events>
-                  <AuxValues>
-                    <AuxValue name="JavaCodeGenerator_InitCodePost" type="java.lang.String" value="comboBoxOccMapping.setEnabled(checkBoxOccChangeMM.isSelected());"/>
-                    <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;OccluderMapper.OccMappingMode&gt;"/>
-                  </AuxValues>
                 </Component>
               </SubComponents>
             </Container>

--- a/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
+++ b/src/main/java/info/ata4/bspsrc/gui/BspSourceFrame.java
@@ -18,8 +18,6 @@ import info.ata4.bspsrc.BspSource;
 import info.ata4.bspsrc.BspSourceConfig;
 import info.ata4.bspsrc.gui.util.EnumToolTexture;
 import info.ata4.bspsrc.modules.geom.BrushMode;
-import info.ata4.bspsrc.util.AreaportalMapper;
-import info.ata4.bspsrc.util.OccluderMapper;
 import info.ata4.bspsrc.util.SourceFormat;
 import info.ata4.log.LogUtils;
 import info.ata4.util.gui.FileDrop;
@@ -134,7 +132,8 @@ public class BspSourceFrame extends javax.swing.JFrame {
 
         // check boxes
         checkBoxAreaportal.setSelected(config.writeAreaportals);
-        checkBoxApChangeMM.setSelected(config.apForceMapping);
+        checkBoxForceApMode.setSelected(config.apForceManualMapping);
+        checkBoxForceOccMode.setSelected(config.occForceManualMapping);
         checkBoxCubemap.setSelected(config.writeCubemaps);
         checkBoxDebugMode.setSelected(config.isDebug());
         checkBoxDetail.setSelected(config.writeDetails);
@@ -162,7 +161,6 @@ public class BspSourceFrame extends javax.swing.JFrame {
         comboBoxFaceTex.setSelectedIndex(0);
         comboBoxMapFormat.setSelectedIndex(0);
         comboBoxSourceFormat.setSelectedIndex(0);
-        comboBoxApMapping.setSelectedIndex(0);
 
         // misc
         listFilesModel.removeAllElements();
@@ -435,11 +433,8 @@ public class BspSourceFrame extends javax.swing.JFrame {
         checkBoxEnableEntities = new javax.swing.JCheckBox();
         jpEntityMapping = new javax.swing.JPanel();
         jpAreaportalMapping = new javax.swing.JPanel();
-        checkBoxApChangeMM = new javax.swing.JCheckBox();
-        comboBoxApMapping = new javax.swing.JComboBox<>();
-        jpOccluderMapping = new javax.swing.JPanel();
-        checkBoxOccChangeMM = new javax.swing.JCheckBox();
-        comboBoxOccMapping = new javax.swing.JComboBox<>();
+        checkBoxForceApMode = new javax.swing.JCheckBox();
+        checkBoxForceOccMode = new javax.swing.JCheckBox();
         panelTextures = new javax.swing.JPanel();
         labelFaceTex = new javax.swing.JLabel();
         labelBackfaceTex = new javax.swing.JLabel();
@@ -784,24 +779,24 @@ public class BspSourceFrame extends javax.swing.JFrame {
 
         jpEntityMapping.setName("Mapping"); // NOI18N
 
-        jpAreaportalMapping.setBorder(javax.swing.BorderFactory.createTitledBorder("Areaportal"));
+        jpAreaportalMapping.setBorder(javax.swing.BorderFactory.createTitledBorder("Force Manual Method"));
         jpAreaportalMapping.setName(""); // NOI18N
-        jpAreaportalMapping.setPreferredSize(new java.awt.Dimension(135, 68));
+        jpAreaportalMapping.setPreferredSize(new java.awt.Dimension(135, 48));
 
-        checkBoxApChangeMM.setText("Force mapping");
-        checkBoxApChangeMM.setToolTipText("This forces the mapping of areaportal to brushes to be made manual. Only check this if you're getting trouble with the default mapping methode");
-        checkBoxApChangeMM.setActionCommand("forceManualMapping");
-        checkBoxApChangeMM.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                checkBoxApChangeMMStateChanged(evt);
+        checkBoxForceApMode.setText("Areaportals");
+        checkBoxForceApMode.setToolTipText("This forces the mapping of areaportals to brushes, to be made manually. Only check this if you're getting errors with the default mapping method!");
+        checkBoxForceApMode.setActionCommand("forceManualMapping");
+        checkBoxForceApMode.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                checkBoxForceApModeItemStateChanged(evt);
             }
         });
 
-        comboBoxApMapping.setModel(new DefaultComboBoxModel<>(AreaportalMapper.ApMappingMode.values()));
-        comboBoxApMapping.setEnabled(checkBoxApChangeMM.isSelected());
-        comboBoxApMapping.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                comboBoxApMappingActionPerformed(evt);
+        checkBoxForceOccMode.setText("Occluders");
+        checkBoxForceOccMode.setToolTipText("This forces the mapping of occluders to brushes, to be made manually. Only check this if you're getting errors with the default mapping method!");
+        checkBoxForceOccMode.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                checkBoxForceOccModeItemStateChanged(evt);
             }
         });
 
@@ -809,50 +804,15 @@ public class BspSourceFrame extends javax.swing.JFrame {
         jpAreaportalMapping.setLayout(jpAreaportalMappingLayout);
         jpAreaportalMappingLayout.setHorizontalGroup(
             jpAreaportalMappingLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addComponent(checkBoxApChangeMM, javax.swing.GroupLayout.DEFAULT_SIZE, 131, Short.MAX_VALUE)
-            .addComponent(comboBoxApMapping, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(checkBoxForceOccMode, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(checkBoxForceApMode, javax.swing.GroupLayout.DEFAULT_SIZE, 133, Short.MAX_VALUE)
         );
         jpAreaportalMappingLayout.setVerticalGroup(
             jpAreaportalMappingLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jpAreaportalMappingLayout.createSequentialGroup()
-                .addComponent(checkBoxApChangeMM)
+                .addComponent(checkBoxForceApMode)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(comboBoxApMapping, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-        );
-
-        jpOccluderMapping.setBorder(javax.swing.BorderFactory.createTitledBorder("Occluder"));
-        jpOccluderMapping.setPreferredSize(new java.awt.Dimension(135, 46));
-
-        checkBoxOccChangeMM.setText("Force mapping");
-        checkBoxOccChangeMM.addChangeListener(new javax.swing.event.ChangeListener() {
-            public void stateChanged(javax.swing.event.ChangeEvent evt) {
-                checkBoxOccChangeMMStateChanged(evt);
-            }
-        });
-
-        comboBoxOccMapping.setModel(new DefaultComboBoxModel<>(OccluderMapper.OccMappingMode.values()));
-        comboBoxOccMapping.setEnabled(checkBoxOccChangeMM.isSelected());
-        comboBoxOccMapping.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                comboBoxOccMappingActionPerformed(evt);
-            }
-        });
-
-        javax.swing.GroupLayout jpOccluderMappingLayout = new javax.swing.GroupLayout(jpOccluderMapping);
-        jpOccluderMapping.setLayout(jpOccluderMappingLayout);
-        jpOccluderMappingLayout.setHorizontalGroup(
-            jpOccluderMappingLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jpOccluderMappingLayout.createSequentialGroup()
-                .addComponent(checkBoxOccChangeMM, javax.swing.GroupLayout.DEFAULT_SIZE, 125, Short.MAX_VALUE)
-                .addContainerGap())
-            .addComponent(comboBoxOccMapping, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-        );
-        jpOccluderMappingLayout.setVerticalGroup(
-            jpOccluderMappingLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(jpOccluderMappingLayout.createSequentialGroup()
-                .addComponent(checkBoxOccChangeMM)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(comboBoxOccMapping, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addComponent(checkBoxForceOccMode))
         );
 
         javax.swing.GroupLayout jpEntityMappingLayout = new javax.swing.GroupLayout(jpEntityMapping);
@@ -861,19 +821,15 @@ public class BspSourceFrame extends javax.swing.JFrame {
             jpEntityMappingLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jpEntityMappingLayout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(jpAreaportalMapping, javax.swing.GroupLayout.PREFERRED_SIZE, 143, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(2, 2, 2)
-                .addComponent(jpOccluderMapping, javax.swing.GroupLayout.PREFERRED_SIZE, 143, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap())
+                .addComponent(jpAreaportalMapping, javax.swing.GroupLayout.PREFERRED_SIZE, 145, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(155, Short.MAX_VALUE))
         );
         jpEntityMappingLayout.setVerticalGroup(
             jpEntityMappingLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jpEntityMappingLayout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(jpEntityMappingLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                    .addComponent(jpOccluderMapping, javax.swing.GroupLayout.DEFAULT_SIZE, 68, Short.MAX_VALUE)
-                    .addComponent(jpAreaportalMapping, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap(121, Short.MAX_VALUE))
+                .addComponent(jpAreaportalMapping, javax.swing.GroupLayout.PREFERRED_SIZE, 69, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(120, Short.MAX_VALUE))
         );
 
         tabbedPaneOptions.addTab("Entity mapping", jpEntityMapping);
@@ -1114,43 +1070,23 @@ public class BspSourceFrame extends javax.swing.JFrame {
         config.writeLadders = checkBoxLadder.isSelected();
     }//GEN-LAST:event_checkBoxLadderActionPerformed
 
-    private void comboBoxApMappingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_comboBoxApMappingActionPerformed
-        config.apMappingMode = (AreaportalMapper.ApMappingMode) comboBoxApMapping.getSelectedItem();
-    }//GEN-LAST:event_comboBoxApMappingActionPerformed
-
-    private void comboBoxOccMappingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_comboBoxOccMappingActionPerformed
-        config.occMappingMode = (OccluderMapper.OccMappingMode) comboBoxOccMapping.getSelectedItem();
-    }//GEN-LAST:event_comboBoxOccMappingActionPerformed
-
     private void checkBoxAreaportalStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxAreaportalStateChanged
         config.writeAreaportals = checkBoxAreaportal.isSelected();
-        checkBoxApChangeMM.setEnabled(checkBoxAreaportal.isSelected());
-        
-        if (!checkBoxAreaportal.isSelected()) {
-            checkBoxApChangeMM.setSelected(false);
-            config.apForceMapping = false;
-        }
+        checkBoxForceApMode.setEnabled(checkBoxAreaportal.isSelected());
     }//GEN-LAST:event_checkBoxAreaportalStateChanged
 
     private void checkBoxOccluderStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxOccluderStateChanged
         config.writeOccluders = checkBoxOccluder.isSelected();
-        checkBoxOccChangeMM.setEnabled(checkBoxOccluder.isSelected());
-        
-        if (!checkBoxOccluder.isSelected()) {
-            checkBoxOccChangeMM.setSelected(false);
-            config.occForceMapping = false;
-        }
+        checkBoxForceOccMode.setEnabled(checkBoxOccluder.isSelected());
     }//GEN-LAST:event_checkBoxOccluderStateChanged
 
-    private void checkBoxApChangeMMStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxApChangeMMStateChanged
-        config.apForceMapping = checkBoxApChangeMM.isSelected();
-        comboBoxApMapping.setEnabled(checkBoxApChangeMM.isSelected());
-    }//GEN-LAST:event_checkBoxApChangeMMStateChanged
+    private void checkBoxForceApModeItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_checkBoxForceApModeItemStateChanged
+        config.apForceManualMapping = checkBoxForceApMode.isSelected();
+    }//GEN-LAST:event_checkBoxForceApModeItemStateChanged
 
-    private void checkBoxOccChangeMMStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_checkBoxOccChangeMMStateChanged
-        config.occForceMapping = checkBoxOccChangeMM.isSelected();
-        comboBoxOccMapping.setEnabled(checkBoxOccChangeMM.isSelected());
-    }//GEN-LAST:event_checkBoxOccChangeMMStateChanged
+    private void checkBoxForceOccModeItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_checkBoxForceOccModeItemStateChanged
+        config.occForceManualMapping = checkBoxForceOccMode.isSelected();
+    }//GEN-LAST:event_checkBoxForceOccModeItemStateChanged
 
     private void checkBoxEnableEntitiesActionPerformed(java.awt.event.ActionEvent evt) {                                                       
         config.setWriteEntities(checkBoxEnableEntities.isSelected());
@@ -1337,7 +1273,6 @@ public class BspSourceFrame extends javax.swing.JFrame {
     private javax.swing.ButtonGroup buttonGroupBrushMode;
     private javax.swing.JButton buttonRemove;
     private javax.swing.JButton buttonRemoveAll;
-    private javax.swing.JCheckBox checkBoxApChangeMM;
     private javax.swing.JCheckBox checkBoxAreaportal;
     private javax.swing.JCheckBox checkBoxCameras;
     private javax.swing.JCheckBox checkBoxCubemap;
@@ -1350,22 +1285,20 @@ public class BspSourceFrame extends javax.swing.JFrame {
     private javax.swing.JCheckBox checkBoxFixCubemapTex;
     private javax.swing.JCheckBox checkBoxFixRotation;
     private javax.swing.JCheckBox checkBoxFixToolTex;
+    private javax.swing.JCheckBox checkBoxForceApMode;
+    private javax.swing.JCheckBox checkBoxForceOccMode;
     private javax.swing.JCheckBox checkBoxLadder;
     private javax.swing.JCheckBox checkBoxLoadLumpFile;
-    private javax.swing.JCheckBox checkBoxOccChangeMM;
     private javax.swing.JCheckBox checkBoxOccluder;
     private javax.swing.JCheckBox checkBoxOverlay;
     private javax.swing.JCheckBox checkBoxPropStatic;
     private javax.swing.JCheckBox checkBoxVisgroups;
-    private javax.swing.JComboBox<AreaportalMapper.ApMappingMode> comboBoxApMapping;
     private javax.swing.JComboBox comboBoxBackfaceTex;
     private javax.swing.JComboBox comboBoxFaceTex;
     private javax.swing.JComboBox comboBoxMapFormat;
-    private javax.swing.JComboBox<OccluderMapper.OccMappingMode> comboBoxOccMapping;
     private javax.swing.JComboBox comboBoxSourceFormat;
     private javax.swing.JPanel jpAreaportalMapping;
     private javax.swing.JPanel jpEntityMapping;
-    private javax.swing.JPanel jpOccluderMapping;
     private javax.swing.JLabel labelBackfaceTex;
     private javax.swing.JLabel labelDnDTip;
     private javax.swing.JLabel labelFaceTex;

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -63,9 +63,11 @@ public class EntitySource extends ModuleDecompile {
     private final VmfMeta vmfmeta;
 
     // Areaportal to brush mapping
+    private AreaportalMapper areaportalMapper;
     private Map<Integer, Integer> apBrushMap;
 
     // Occluder to brushes mapping;
+    private OccluderMapper occluderMapper;
     private Map<Integer, Set<Integer>> occBrushesMap;
 
     //'No More Room in Hell' Nmo data
@@ -87,10 +89,10 @@ public class EntitySource extends ModuleDecompile {
 
         processEntities();
 
-        AreaportalMapper areaportalMapper = new AreaportalMapper(bsp, config);
+        areaportalMapper = new AreaportalMapper(bsp, config);
         apBrushMap = areaportalMapper.getApBrushMapping();
 
-        OccluderMapper occluderMapper = new OccluderMapper(bsp, config);
+        occluderMapper = new OccluderMapper(bsp, config);
         occBrushesMap = occluderMapper.getOccBrushMapping();
 
         // Because the Texturebuilder needs to know which brush is a occluder we flag them here. (The Texturebuilder needs to know this information, because the brushside that represents the occluder has almost always the wrong tooltexture applied, which we need to fix)
@@ -329,6 +331,10 @@ public class EntitySource extends ModuleDecompile {
                         facesrc.writeAreaportal(portalNum);
                         visgroups.add("Rebuild" + VmfMeta.VISGROUP_SEPERATOR + "areaportals");
                     }
+
+                    if (config.isDebug()) {
+                        visgroups.add("AreaportalID" + VmfMeta.VISGROUP_SEPERATOR + portalNum);
+                    }
                 }
 
                 // retrieve occluder brushes from map
@@ -380,6 +386,11 @@ public class EntitySource extends ModuleDecompile {
             }
 
             writer.end("entity");
+        }
+
+        //If were in debug wer write some additional entities
+        if (config.isDebug()) {
+            areaportalMapper.writeDebugPortals(writer, vmfmeta, facesrc);
         }
     }
 

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -191,25 +191,6 @@ public class EntitySource extends ModuleDecompile {
                 }
             }
 
-            // re-use hammerid if possible, otherwise generate a new UID
-            int entID = getHammerID(ent);
-
-            // if we have nmo data re-use extractions ids
-            if (nmo != null) {
-                entID = nmo.extractions.stream()
-                        .filter(extraction -> extraction.name.equals(ent.getTargetName()))
-                        .findAny()
-                        .map(extraction -> extraction.id)
-                        .orElse(entID);
-            }
-
-            if (entID == -1) {
-                entID = vmfmeta.getUID();
-            }
-
-            writer.start("entity");
-            writer.put("id", entID);
-
             // get areaportal numbers
             int portalNum = -1;
             if (isAreaportal) {
@@ -221,6 +202,12 @@ public class EntitySource extends ModuleDecompile {
                         portalNum = Integer.valueOf(portalNumString);
                     } catch (NumberFormatException ex) {
                         portalNum = -1;
+                    }
+
+                    int finalPortalNum = portalNum;
+                    if (bsp.areaportals.stream().noneMatch(areaportal -> areaportal.portalKey == finalPortalNum)) {
+                        L.warning("funct_areaportal entity links to a non existing areaportal, skipping...");
+                        continue;
                     }
 
                     // keep the number when debugging
@@ -249,6 +236,25 @@ public class EntitySource extends ModuleDecompile {
                     }
                 }
             }
+
+            // re-use hammerid if possible, otherwise generate a new UID
+            int entID = getHammerID(ent);
+
+            // if we have nmo data re-use extractions ids
+            if (nmo != null) {
+                entID = nmo.extractions.stream()
+                        .filter(extraction -> extraction.name.equals(ent.getTargetName()))
+                        .findAny()
+                        .map(extraction -> extraction.id)
+                        .orElse(entID);
+            }
+
+            if (entID == -1) {
+                entID = vmfmeta.getUID();
+            }
+
+            writer.start("entity");
+            writer.put("id", entID);
 
             int modelNum = ent.getModelNum();
 

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -62,10 +62,10 @@ public class EntitySource extends ModuleDecompile {
     private final VmfMeta vmfmeta;
 
     // Areaportal to brush mapping
-    Map<Integer, Integer> apBrushMap;
+    private Map<Integer, Integer> apBrushMap;
 
     // Occluder to brushes mapping;
-    Map<Integer, List<Integer>> occBrushesMap;
+    private Map<Integer, Set<Integer>> occBrushesMap;
 
     //'No More Room in Hell' Nmo data
     private NmoFile nmo;

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -18,7 +18,8 @@ import info.ata4.bsplib.entity.KeyValue;
 import info.ata4.bsplib.nmo.NmoFile;
 import info.ata4.bsplib.struct.*;
 import info.ata4.bsplib.vector.Vector3f;
-import info.ata4.bspsrc.*;
+import info.ata4.bspsrc.BspSourceConfig;
+import info.ata4.bspsrc.VmfWriter;
 import info.ata4.bspsrc.modules.BspProtection;
 import info.ata4.bspsrc.modules.ModuleDecompile;
 import info.ata4.bspsrc.modules.VmfMeta;
@@ -91,6 +92,9 @@ public class EntitySource extends ModuleDecompile {
 
         OccluderMapper occluderMapper = new OccluderMapper(bsp, config);
         occBrushesMap = occluderMapper.getOccBrushMapping();
+
+        // Because the Texturebuilder needs to know which brush is a occluder we flag them here. (The Texturebuilder needs to know this information, because the brushside that represents the occluder has almost always the wrong tooltexture applied, which we need to fix)
+        occBrushesMap.values().forEach(brushIndexes -> brushIndexes.forEach(index -> bsp.brushes.get(index).flagAsOccluder(true)));
     }
 
     /**

--- a/src/main/java/info/ata4/bspsrc/modules/geom/FaceSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/geom/FaceSource.java
@@ -17,21 +17,12 @@ import info.ata4.bspsrc.BspSourceConfig;
 import info.ata4.bspsrc.VmfWriter;
 import info.ata4.bspsrc.modules.ModuleDecompile;
 import info.ata4.bspsrc.modules.VmfMeta;
-import info.ata4.bspsrc.modules.texture.Texture;
-import info.ata4.bspsrc.modules.texture.TextureAxis;
-import info.ata4.bspsrc.modules.texture.TextureBuilder;
-import info.ata4.bspsrc.modules.texture.TextureSource;
-import info.ata4.bspsrc.modules.texture.ToolTexture;
+import info.ata4.bspsrc.modules.texture.*;
 import info.ata4.bspsrc.util.Winding;
 import info.ata4.bspsrc.util.WindingFactory;
 import info.ata4.log.LogUtils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -471,6 +462,7 @@ public class FaceSource extends ModuleDecompile {
                 return;
             }
         }
+        L.warning("Tried to write non existing areaportal with portalkey " + portalKey);
     }
 
     public void writeAreaportal(DAreaportal ap) {

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -3,10 +3,7 @@ package info.ata4.bspsrc.util;
 import info.ata4.bsplib.struct.BspData;
 import info.ata4.bsplib.struct.DAreaportal;
 import info.ata4.bsplib.struct.DBrush;
-import info.ata4.bsplib.struct.DBrushSide;
 import info.ata4.bsplib.util.VectorUtil;
-import info.ata4.bsplib.vector.Vector2f;
-import info.ata4.bsplib.vector.Vector3f;
 import info.ata4.bspsrc.BspSourceConfig;
 import info.ata4.log.LogUtils;
 
@@ -208,9 +205,14 @@ public class AreaportalMapper {
      *
      * @return A {@code Map} where the keys represent portal ids and values the brush ids
      */
-    public Map<Integer,Integer> getApBrushMapping() {
+    public Map<Integer, Integer> getApBrushMapping() {
         if (!config.writeAreaportals)
             return Collections.emptyMap();
+
+        if (areaportalHelpers.size() == 0) {
+            L.info("No areaportals to reallocate...");
+            return Collections.emptyMap();
+        }
 
         if (config.apForceMapping) {
             L.info("Forced areaportal method: '" + config.apMappingMode + "'");
@@ -218,10 +220,10 @@ public class AreaportalMapper {
         }
 
         if (areaportalHelpers.stream().mapToInt(value -> value.portalID.size()).sum() == bsp.brushes.stream().filter(DBrush::isAreaportal).count()) {
-            L.info("Equal amount of areaporal entities as areaportal brushes. Using '" + ApMappingMode.ORDERED + "' method");
+            L.info("Equal amount of areaporal entities and areaportal brushes. Using '" + ApMappingMode.ORDERED + "' method");
             return ApMappingMode.ORDERED.map(this);
         } else {
-            L.info("Unequal amount of areaporal entities as areaportal brushes. Falling back to '" + ApMappingMode.MANUAL + "' method");
+            L.info("Unequal amount of areaporal entities and areaportal brushes. Falling back to '" + ApMappingMode.MANUAL + "' method");
             return ApMappingMode.MANUAL.map(this);
         }
     }

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -253,9 +253,9 @@ public class AreaportalMapper {
             return Collections.emptyMap();
         }
 
-        if (config.apForceMapping) {
-            L.info("Forced areaportal method: '" + config.apMappingMode + "'");
-            return config.apMappingMode.map(this);
+        if (config.apForceManualMapping) {
+            L.info("Forced manual areaportal mapping method");
+            return ApMappingMode.MANUAL.map(this);
         }
 
         if (areaportalHelpers.stream().mapToInt(value -> value.portalID.size()).sum() == bsp.brushes.stream().filter(DBrush::isAreaportal).count()) {

--- a/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
@@ -97,10 +97,6 @@ public class OccluderMapper {
         // Remove every occluder mapping that has 0 brushes assigned, because we couldn't find a mapping
         occBrushMapping.values().removeIf(list -> list.size() == 0);
 
-        // Because the Texturebuilder needs to know which brush is a occluder we flag them here. (The Texturebuilder needs to know this information, because the brushside that represents the occluder has almost always the wrong tooltexture applied, which we need to fix)
-        occBrushMapping.values().forEach(brushIndexes -> brushIndexes.forEach(index -> bsp.brushes.get(index).flagAsOccluder(true)));
-
-
         return occBrushMapping;
     }
 
@@ -180,14 +176,6 @@ public class OccluderMapper {
             remaining = j;
 
             occBrushMap.put(occBrushMap.size(), occBrushes);
-
-            // Because the Texturebuilder needs to know which brush is a occluder we flag them here. (The Texturebuilder needs to know this information because the brushside that represents the occluder has almost always the wrong tooltexture applied)
-            for (int brushID: occBrushes) {
-                if (brushID == -1)
-                    continue;
-
-                bsp.brushes.get(brushID).flagAsOccluder(true);
-            }
         }
         return occBrushMap;
     }

--- a/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
@@ -173,6 +173,11 @@ public class OccluderMapper {
         if (!config.writeOccluders)
             return Collections.emptyMap();
 
+        if (bsp.occluderDatas.size() == 0) {
+            L.info("No occluders to reallocate...");
+            return Collections.emptyMap();
+        }
+
         if (config.occForceMapping) {
             L.info("Forced occluder method: '" + config.occMappingMode + "'");
             return config.occMappingMode.map(this);
@@ -187,10 +192,10 @@ public class OccluderMapper {
                 .sum();
 
         if (occluderFacesNum == occluderBrushFacesNum) {
-            L.info("Equal amount of occluder faces as occluder brush faces. Using '" + OccMappingMode.ORDERED + "' method");
+            L.info("Equal amount of occluder faces and occluder brush faces. Using '" + OccMappingMode.ORDERED + "' method");
             return OccMappingMode.ORDERED.map(this);
         } else {
-            L.info("Unequal amount of occluder faces as occluder brush faces. Falling back to '" + OccMappingMode.MANUAL + "' method");
+            L.info("Unequal amount of occluder faces and occluder brush faces. Falling back to '" + OccMappingMode.MANUAL + "' method");
             return OccMappingMode.MANUAL.map(this);
         }
     }

--- a/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
@@ -178,9 +178,9 @@ public class OccluderMapper {
             return Collections.emptyMap();
         }
 
-        if (config.occForceMapping) {
-            L.info("Forced occluder method: '" + config.occMappingMode + "'");
-            return config.occMappingMode.map(this);
+        if (config.occForceManualMapping) {
+            L.info("Forced manual occluder mapping method");
+            return OccMappingMode.MANUAL.map(this);
         }
 
         int occluderFacesNum = potentialOccluderBrushes.values().stream()

--- a/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
@@ -3,7 +3,6 @@ package info.ata4.bspsrc.util;
 import info.ata4.bsplib.struct.*;
 import info.ata4.bsplib.util.VectorUtil;
 import info.ata4.bspsrc.BspSourceConfig;
-import info.ata4.bspsrc.modules.texture.ToolTexture;
 import info.ata4.log.LogUtils;
 
 import java.util.*;
@@ -11,9 +10,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 /**
- *
  * Class for mapping occluder entities to their original brushes
  */
 public class OccluderMapper {
@@ -23,17 +23,23 @@ public class OccluderMapper {
     private BspSourceConfig config;
     private BspData bsp;
 
-    // Occluders aren't worldbrushes, so we can limit our 'search' by limiting the brushes to non worldbrushes
+    /**
+     * Occluders aren't worldbrushes, so we can limit our 'search' by limiting the brushes to non worldbrushes.
+     * This is used for both {@link OccMappingMode#MANUAL} and  {@link OccMappingMode#ORDERED}
+     */
     private ArrayList<DBrush> nonWorldBrushes;
 
-    // ONLY used for 'ORDERED MAPPING'
-    private ArrayList<DBrush> potentialOccluderBrushes;
-    private Map<Integer, Integer> occluderFaces;
+    /**
+     * ONLY used for {@link OccMappingMode#ORDERED}
+     */
+    private SortedMap<Integer, Integer> potentialOccluderBrushes;
 
-    // Predicate that test if a texture name matches one of the valid occluder texture names.
-    // ONLY used for 'ORDERED MAPPING', because for some reason vBsp sometimes changes textures of all occluders to some arbitrary texture
-    private static final Predicate<String> matchesOccluder = s -> s.equalsIgnoreCase(ToolTexture.TRIGGER) ||
-                                                            s.equalsIgnoreCase(ToolTexture.OCCLUDER);
+    /**
+     * Predicate that test if a {@link DTexInfo} matches one that would be used for occluder brush sides.
+     * ONLY used for {@link OccMappingMode#ORDERED}, because I'm not sure if other games use different SurfaceFlags!
+     */
+    private static final Predicate<DTexInfo> matchesOccluderTexInfo = dTexInfo -> dTexInfo.flags.equals(EnumSet.of(SurfaceFlag.SURF_NOLIGHT)) || dTexInfo.flags.equals(EnumSet.of(SurfaceFlag.SURF_TRIGGER, SurfaceFlag.SURF_NOLIGHT));
+
 
     public OccluderMapper(BspData bsp, BspSourceConfig config) {
         this.config = config;
@@ -41,58 +47,49 @@ public class OccluderMapper {
 
         prepareNonWorldBrushes();
         preparePotentialOccBrushes();
-        prepareOccluderFaces();
     }
 
     private void prepareNonWorldBrushes()
     {
-        BspTreeStats t = new BspTreeStats(bsp);
-        t.walk(0);
+        BspTreeStats tree = new BspTreeStats(bsp);
+        tree.walk(0);
 
-        nonWorldBrushes = new ArrayList<>(bsp.brushes.subList(t.getMaxBrushLeaf() + 1, bsp.brushes.size()));
+        nonWorldBrushes = new ArrayList<>(bsp.brushes.subList(tree.getMaxBrushLeaf() + 1, bsp.brushes.size()));
     }
 
     /**
-     * Fills {@code potentialOccluderBrushes} with potential brushes that could have represented occluders
+     * Because there is no direct way of determining if a brush was used as an occluder, we have to use a process of elimination to get a list of potential occluder brushes.
+     * Fills {@code potentialOccluderBrushes} with potential brushes, that could have represented occluders as keys and and the amount of brush sides, that could have represented occluder faces as values
      */
     private void preparePotentialOccBrushes() {
-        potentialOccluderBrushes = nonWorldBrushes.stream()                                                                 // Iterate over every existing brush
-                .filter(dBrush -> !dBrush.isDetail())                                                                   // - Filter all out that have the 'detail' flag
-                .filter(dBrush -> !dBrush.isAreaportal())                                                               // - Filter all out that have the 'areaportal' flag
-                .filter(dBrush -> bsp.brushSides.subList(dBrush.fstside, dBrush.fstside + dBrush.numside).stream()      // - Iterate over every brush side and test if it texture matches 'matchesOccluder'
-                        .map(dBrushSide -> bsp.texinfos.get((int) dBrushSide.texinfo))                                  // -- Map brushside to textinfo
-                        .filter(dTexInfo -> dTexInfo.texdata >= 0)                                                      // -- Skip brushsides that don't have textdata
-                        .map(dTexInfo -> bsp.texdatas.get(dTexInfo.texdata))                                            // -- Map textinfo to textdata
-                        .map(dTexData -> bsp.texnames.get(dTexData.texname))                                            // -- Map textdata to textname
-                        .anyMatch(matchesOccluder)                                                                      // -- Test if any texture matches 'matchesOccluder'
-                )
-                .collect(Collectors.toCollection(ArrayList::new));                                                      // - Collect every brush into a list that had at ^2least one brushside that matched 'matchesOccluder'
+        potentialOccluderBrushes = nonWorldBrushes.stream()
+                .filter(dBrush -> dBrush.contents.equals(EnumSet.of(BrushFlag.CONTENTS_SOLID))) // Every occluder brush only seems to have this one BrushFlag
+                .collect(Collectors.toMap(
+                        bsp.brushes::indexOf,
+                        dBrush -> (int) bsp.brushSides.subList(dBrush.fstside, dBrush.fstside + dBrush.numside).stream()
+                                .map(dBrushSide -> bsp.texinfos.get(dBrushSide.texinfo))
+                                .filter(matchesOccluderTexInfo)
+                                .count(),
+                        (u,v) -> { throw new IllegalStateException(String.format("Duplicate key %s", u)); },
+                        TreeMap::new    //Important! because we wanna preserve the index order of the original brush lump, so we can use it in the 'ORDERED MAPPING' method
+                ));
+
+        // Remove every brush, that didn't actually had a brush side which could be a potential occluder face
+        potentialOccluderBrushes.values().removeIf(faceCount -> faceCount == 0);
     }
 
     /**
-     * Fills {@code occluderFaces} with all potential brushes mapped an {@code Integer} representing the number of faces that matches '{@code matchesOccluder}'
-     */
-    private void prepareOccluderFaces() {
-        occluderFaces = potentialOccluderBrushes.stream()
-                .collect(Collectors.toMap(dBrush -> bsp.brushes.indexOf(dBrush), dBrush -> (int) bsp.brushSides.subList(dBrush.fstside, dBrush.fstside + dBrush.numside).stream()
-                        .map(dBrushSide -> bsp.texinfos.get((int) dBrushSide.texinfo))
-                        .filter(dTexInfo -> dTexInfo.texdata >= 0)
-                        .map(dTexInfo -> bsp.texdatas.get(dTexInfo.texdata))
-                        .map(dTexData -> bsp.texnames.get(dTexData.texname))
-                        .filter(matchesOccluder)
-                        .count())
-                );
-    }
-
-    /**
-     * Maps all occluder entities to their brushes in form of a {@code Map}
+     * Maps all {@link DOccluderData} to their original brushes by comparing their faces to brush sides and determining if they are similar (Identical or contained in the brushside)
      *
-     * @return A {@code Map} where the keys represent an occluder an the values a list of brush ids
+     * @return A {@link Map} where the keys represent an occluder an the values a list of brush ids
      */
     private Map<Integer, Set<Integer>> manualMapping() {
         // Map all occluders to a list of representing brushes
         Map<Integer, Set<Integer>> occBrushMapping = bsp.occluderDatas.stream()
-                .collect(Collectors.toMap(dOccluderData -> bsp.occluderDatas.indexOf(dOccluderData), this::mapOccluder));
+                .collect(Collectors.toMap(
+                        dOccluderData -> bsp.occluderDatas.indexOf(dOccluderData),
+                        this::mapOccluder
+                ));
 
         // Remove every occluder mapping that has 0 brushes assigned, because we couldn't find a mapping
         occBrushMapping.values().removeIf(list -> list.size() == 0);
@@ -101,20 +98,22 @@ public class OccluderMapper {
     }
 
     /**
-     * Finds all brushes that represent this occluder and return their indexes of bsp.brushes
+     * Finds all brushes that represent this occluder and return their index in {@link BspData#brushes}
      *
      * @param dOccluderData occluder to find brushes for
-     * @return a Integer list of brush indexes
+     * @return an Integer list of brush indexes
      */
     private Set<Integer> mapOccluder(DOccluderData dOccluderData) {
         return bsp.occluderPolyDatas.subList(dOccluderData.firstpoly, dOccluderData.firstpoly + dOccluderData.polycount).stream()
                 .map(dOccluderPolyData -> nonWorldBrushes.stream()
                         .filter(dBrush -> bsp.brushSides.subList(dBrush.fstside, dBrush.fstside + dBrush.numside).stream()
-                                .anyMatch(brushSide -> occFacesContainsBrushFace(dOccluderPolyData, dBrush, brushSide)))
-                        .findAny())
+                                .anyMatch(brushSide -> occFacesContainsBrushFace(dOccluderPolyData, dBrush, brushSide))
+                        )
+                        .findAny()
+                )
                 .filter(Optional::isPresent)
-                .map(dBrush -> bsp.brushes.indexOf(dBrush.get()))
-                .filter(index -> index != -1)   //Shouldn't happen, but just in case 'indexOf' returns -1 we filter these out here
+                .map(optionalDBrush -> bsp.brushes.indexOf(optionalDBrush.get()))
+                .filter(index -> {assert index != -1; return index != -1;})   //Shouldn't happen, but just in case 'indexOf' returns -1 we filter these out here
                 .collect(Collectors.toSet());
     }
 
@@ -136,48 +135,29 @@ public class OccluderMapper {
      * @return A {@code Map} with occluder ids as keys and and a List of Integers as values
      */
     private Map<Integer, Set<Integer>> orderedMapping() {
-        // Get the min amount of occluder faces that can be process#
-        // This should always be limited by the amount of occluderData but we test nonetheless
-        long min = Math.min(occluderFaces.values().stream().mapToInt(i -> i).sum(), bsp.occluderDatas.stream().mapToInt(occluder -> occluder.polycount).sum());
+        List<Integer> reverseOccluderFaces = bsp.occluderDatas.stream()
+                .flatMap(dOccluderData -> IntStream.range(0, dOccluderData.polycount)
+                        .mapToObj(value -> bsp.occluderDatas.indexOf(dOccluderData))
+                )
+                .collect(Collectors.toList());
 
-        HashMap<Integer, Set<Integer>> occBrushMap = new HashMap<>();
+        List<Integer> reverseBrushFaces = potentialOccluderBrushes.entrySet().stream()
+                .flatMap(entry -> LongStream.range(0, entry.getValue())
+                        .mapToObj(value -> entry.getKey())
+                )
+                .sorted()
+                .collect(Collectors.toList());
 
-        // Convert the amount of occluderfaces we can process into actual occluders (occluders can have multiple faces)
-        int minOccluders = 0;
-        int index = 0;
-        while (min > 0) {
-            if (bsp.occluderDatas.get(index).polycount > min)
-                break;
+        int min = Math.min(reverseOccluderFaces.size(), reverseBrushFaces.size());
 
-            min -= bsp.occluderDatas.get(index).polycount;
-            minOccluders++;
-            index++;
-        }
-
-        // Map all occluder to brushes in ascending brush index order
-        // And yeah, i know this complete method looks very ulgy. Didn't know how to write a better algorithm for this
-        int occBrushIndex = 0;
-        int remaining = 0;
-        for (int i = 0; i < minOccluders; i++) {
-            Set<Integer> occBrushes = new HashSet<>();
-
-            int j = bsp.occluderDatas.get(i).polycount;
-            while (j > 0) {
-                occBrushes.add(bsp.brushes.indexOf(potentialOccluderBrushes.get(occBrushIndex)));
-                if (remaining < 0)
-                    j -= remaining;
-                else
-                    j -= occluderFaces.get(bsp.brushes.indexOf(potentialOccluderBrushes.get(occBrushIndex)));
-                remaining = 0;
-
-                if (j >= 0)
-                    occBrushIndex++;
-            }
-            remaining = j;
-
-            occBrushMap.put(occBrushMap.size(), occBrushes);
-        }
-        return occBrushMap;
+        return IntStream.range(0, min)
+                .boxed()
+                .collect(Collectors.groupingBy(reverseOccluderFaces::get, Collectors.collectingAndThen(
+                        Collectors.toSet(),
+                        indices -> indices.stream()
+                                .map(reverseBrushFaces::get)
+                                .collect(Collectors.toSet())
+                )));
     }
 
     /**
@@ -198,7 +178,7 @@ public class OccluderMapper {
             return config.occMappingMode.map(this);
         }
 
-        int occluderFacesNum = occluderFaces.values().stream()
+        int occluderFacesNum = potentialOccluderBrushes.values().stream()
                 .mapToInt(i -> i)
                 .sum();
 

--- a/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
@@ -89,9 +89,9 @@ public class OccluderMapper {
      *
      * @return A {@code Map} where the keys represent an occluder an the values a list of brush ids
      */
-    private Map<Integer, List<Integer>> manualMapping() {
+    private Map<Integer, Set<Integer>> manualMapping() {
         // Map all occluders to a list of representing brushes
-        Map<Integer, List<Integer>> occBrushMapping = bsp.occluderDatas.stream()
+        Map<Integer, Set<Integer>> occBrushMapping = bsp.occluderDatas.stream()
                 .collect(Collectors.toMap(dOccluderData -> bsp.occluderDatas.indexOf(dOccluderData), this::mapOccluder));
 
         // Remove every occluder mapping that has 0 brushes assigned, because we couldn't find a mapping
@@ -110,7 +110,7 @@ public class OccluderMapper {
      * @param dOccluderData occluder to find brushes for
      * @return a Integer list of brush indexes
      */
-    private List<Integer> mapOccluder(DOccluderData dOccluderData) {
+    private Set<Integer> mapOccluder(DOccluderData dOccluderData) {
         return bsp.occluderPolyDatas.subList(dOccluderData.firstpoly, dOccluderData.firstpoly + dOccluderData.polycount).stream()
                 .map(dOccluderPolyData -> nonWorldBrushes.stream()
                         .filter(dBrush -> bsp.brushSides.subList(dBrush.fstside, dBrush.fstside + dBrush.numside).stream()
@@ -119,7 +119,7 @@ public class OccluderMapper {
                 .filter(Optional::isPresent)
                 .map(dBrush -> bsp.brushes.indexOf(dBrush.get()))
                 .filter(index -> index != -1)   //Shouldn't happen, but just in case 'indexOf' returns -1 we filter these out here
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -158,12 +158,12 @@ public class OccluderMapper {
      *
      * @return A {@code Map} with occluder ids as keys and and a List of Integers as values
      */
-    private Map<Integer, List<Integer>> orderedMapping() {
+    private Map<Integer, Set<Integer>> orderedMapping() {
         // Get the min amount of occluder faces that can be process#
         // This should always be limited by the amount of occluderData but we test nonetheless
         long min = Math.min(occluderFaces.values().stream().mapToInt(i -> i).sum(), bsp.occluderDatas.stream().mapToInt(occluder -> occluder.polycount).sum());
 
-        HashMap<Integer, List<Integer>> occBrushMap = new HashMap<>();
+        HashMap<Integer, Set<Integer>> occBrushMap = new HashMap<>();
 
         // Convert the amount of occluderfaces we can process into actual occluders (occluders can have multiple faces)
         int minOccluders = 0;
@@ -182,7 +182,7 @@ public class OccluderMapper {
         int occBrushIndex = 0;
         int remaining = 0;
         for (int i = 0; i < minOccluders; i++) {
-            ArrayList<Integer> occBrushes = new ArrayList<>();
+            Set<Integer> occBrushes = new HashSet<>();
 
             int j = bsp.occluderDatas.get(i).polycount;
             while (j > 0) {
@@ -220,7 +220,7 @@ public class OccluderMapper {
      *
      * @return A {@code Map} where the keys represent occluder ids and values a list of brush ids
      */
-    public Map<Integer, List<Integer>> getOccBrushMapping() {
+    public Map<Integer, Set<Integer>> getOccBrushMapping() {
         if (!config.writeOccluders)
             return Collections.emptyMap();
 
@@ -250,13 +250,13 @@ public class OccluderMapper {
         MANUAL(OccluderMapper::manualMapping),
         ORDERED(OccluderMapper::orderedMapping);
 
-        private Function<OccluderMapper, Map<Integer, List<Integer>>> mapper;
+        private Function<OccluderMapper, Map<Integer, Set<Integer>>> mapper;
 
-        OccMappingMode(Function<OccluderMapper, Map<Integer, List<Integer>>> mapper) {
+        OccMappingMode(Function<OccluderMapper, Map<Integer, Set<Integer>>> mapper) {
             this.mapper = mapper;
         }
 
-        public Map<Integer, List<Integer>> map(OccluderMapper occMapper) {
+        public Map<Integer, Set<Integer>> map(OccluderMapper occMapper) {
             return mapper.apply(occMapper);
         }
 

--- a/src/main/java/info/ata4/bspsrc/util/Winding.java
+++ b/src/main/java/info/ata4/bspsrc/util/Winding.java
@@ -10,11 +10,10 @@
 
 package info.ata4.bspsrc.util;
 
-import info.ata4.bsplib.struct.*;
+import info.ata4.bsplib.struct.DPlane;
 import info.ata4.bsplib.vector.Vector3f;
+
 import java.util.*;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
  * Winding utility class.
@@ -206,7 +205,7 @@ public class Winding implements List<Vector3f> {
         return clipEpsilon(pl.normal, pl.dist, EPS_SPLIT, back);
     }
 
-   /**
+    /**
      * Removes degenerated vertices from this winding. A vertex is degenerated
      * when its distance to the previous vertex is smaller than {@link EPS_DEGEN}.
      * 
@@ -401,47 +400,6 @@ public class Winding implements List<Vector3f> {
         return true;
     }
 
-    /**
-     * Checks if this Winding intersects/touches with another one
-     * TODO: This algorithem is probably realy poorly implemented. Should be replaced by a optimized one
-     *
-     * @param w the other winding
-     * @return true if they intersect/touch, else false
-     */
-    public boolean intersect(Winding w) {
-        //Saves all vertices from 'w' into a set
-        HashSet<Vector3f> vertices = new HashSet<>(w);
-
-        if (size() < 3 || w.size() < 3)
-            return false;
-
-        Vector3f[] plane = buildPlane();
-        Vector3f vec1 = plane[1].sub(plane[0]);
-        Vector3f vec2 = plane[2].sub(plane[0]);
-        Vector3f normal = vec2.cross(vec1);
-        float dist = normal.normalize().dot(new Vector3f(0f, 0f, 0f).sub(plane[0]));
-
-        Vector3f[] wPlane = w.buildPlane();
-        Vector3f wVec1 = wPlane[1].sub(wPlane[0]);
-        Vector3f wVec2 = wPlane[2].sub(wPlane[0]);
-        Vector3f wNormal = wVec2.cross(wVec1);
-        float wDist = wNormal.normalize().dot(new Vector3f(0f, 0f, 0f).sub(wPlane[0]));
-
-        if (Math.abs(wNormal.dot(normal) / (wNormal.length() * normal.length())) < 1 - EPS_DEGEN)                       //TODO: Maybe remove 'EPS_DEGEN'. I have no idea if this is need here or how you should even use it
-            return false;
-
-        if (!(Math.abs(dist) + EPS_DEGEN >= Math.abs(wDist) && Math.abs(dist) - EPS_DEGEN <= Math.abs(wDist)))          //TODO: Maybe remove 'EPS_DEGEN'. I have no idea if this is need here or how you should even use it
-            return false;
-
-        return IntStream.range(0, size())
-                .allMatch(i -> {
-                    Vector3f edge = get((i + 1) % size()).sub(get(i));
-                    Vector3f edgeNormal = normal.cross(edge).normalize();
-
-                    return vertices.stream().anyMatch(vertex -> edgeNormal.dot(vertex.sub(get(i))) <= 0);
-                });
-    }
-
     public AABB getBounds() {
         Vector3f mins = Vector3f.MAX_VALUE;
         Vector3f maxs = Vector3f.MIN_VALUE;
@@ -452,38 +410,6 @@ public class Winding implements List<Vector3f> {
         }
 
         return new AABB(mins, maxs);
-    }
-
-
-    /**
-     * Checks if this winding shares the same plane with the other one
-     *
-     * @param w the other winding
-     * @return true if both windings share the same plane otherwise false
-     */
-    public boolean isInSamePlane(Winding w)
-    {
-        // A wingind with only 2 vertices can't build a plane
-        if (size() < 3 || w.size() < 3)
-            return false;
-
-        Vector3f[] plane = buildPlane();
-        Vector3f vec1 = plane[1].sub(plane[0]);
-        Vector3f vec2 = plane[2].sub(plane[0]);
-        Vector3f normal = vec2.cross(vec1);
-        float dist = normal.normalize().dot(new Vector3f(0f, 0f, 0f).sub(plane[0]));
-
-        Vector3f[] wPlane = w.buildPlane();
-        Vector3f wVec1 = wPlane[1].sub(wPlane[0]);
-        Vector3f wVec2 = wPlane[2].sub(wPlane[0]);
-        Vector3f wNormal = wVec2.cross(wVec1);
-        float wDist = wNormal.normalize().dot(new Vector3f(0f, 0f, 0f).sub(wPlane[0]));
-
-        Vector3f cross = wNormal.normalize().cross(normal.normalize());
-        if (cross.dot(cross) < 0.001)                                           //TODO: I have no idea how you would actually mathematically compute the error margine, so im just using a guessed one here
-            return Math.abs(Math.abs(dist) - Math.abs(wDist)) < EPS_DEGEN;      //TODO: Maybe remove 'EPS_DEGEN'. I have no idea if this is needed here or how you should even use it
-        else
-            return false;
     }
 
     /**


### PR DESCRIPTION
## This PR is a general collection of bug fixes related to the Areaportal/Occluder brush mapping system ##

Changes are:
- A rare issue where the Occluder mapper fails to properly reallocate occluders.
This was caused by vBsp sometimes cutting an occluder brush side into multiple occluder faces. (I didn't even know that was possible). To fix this, I changed the OccluderMapper to use a similar system to the AreaportalMapper, which is based on probabilities.
- An issue where the probability algorithm considered 2 identical planes not to share the same plane. This happened when the planes 'faced' the opposite directions, (Normal vectors parallel but not identical)
- `Ordered` mapping mode of the OccluderMapper now uses surface flags and brush flags instead of texture name to identify potential occluder brushes. The reasoning behind this is, that texture names often get changed because of optimization performed by vbsp, while brush flags and surface flags are guaranteed to stay the same.
- Generally some improvements in error handling. View commit message of da23dd38cb26543c1d76db8904c3db92fbab243c for more information.
- Gui simplification. Read commit message of ce663368fb7cd0636089c2a6c1cf956e9debd51c for more information.

Lastly, there are again a lot of syntax changes, partially required so the OccluderMapper can make use of the probability algorithm of the AreaportalMapper and partially to hopefully increase readability.