### PR TITLE
Implemented support for vindictus prop scaling

### DIFF
--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV6VIN.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV6VIN.java
@@ -1,0 +1,8 @@
+package info.ata4.bsplib.struct;
+
+import info.ata4.bsplib.vector.Vector3f;
+
+public class DStaticPropV6VIN extends DStaticPropV5 {
+
+    public Vector3f scaling = new Vector3f(1, 1, 1);
+}

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -18,7 +18,8 @@ import info.ata4.bsplib.entity.KeyValue;
 import info.ata4.bsplib.nmo.NmoFile;
 import info.ata4.bsplib.struct.*;
 import info.ata4.bsplib.vector.Vector3f;
-import info.ata4.bspsrc.*;
+import info.ata4.bspsrc.BspSourceConfig;
+import info.ata4.bspsrc.VmfWriter;
 import info.ata4.bspsrc.modules.BspProtection;
 import info.ata4.bspsrc.modules.ModuleDecompile;
 import info.ata4.bspsrc.modules.VmfMeta;
@@ -668,6 +669,10 @@ public class EntitySource extends ModuleDecompile {
                 writer.put("maxdxlevel", pst6.maxDXLevel);
                 writer.put("mindxlevel", pst6.minDXLevel);
                 writer.put("ignorenormals", pst6.hasIgnoreNormals());
+            }
+
+            if (pst instanceof DStaticPropV6VIN) {
+                writer.put("scale", ((DStaticPropV6VIN) pst).scaling);
             }
 
             // write that later; both v7 and v8 have it, but v8 extends v5


### PR DESCRIPTION
This PR adds support for vindictus prop scaling.
This in its self isn't really useful, because vindictus doesn't have an official SDK but this may help people, who want to port a specific map to another game which does supports prop scaling.
The scaling is saved for the static prop as a made up property named `scale`.

Fixes #62 