### PR TITLE
Fixed missing textures with languages like Turkish

### DIFF
--- a/src/main/java/info/ata4/bsplib/app/SourceApp.java
+++ b/src/main/java/info/ata4/bsplib/app/SourceApp.java
@@ -10,9 +10,11 @@
 package info.ata4.bsplib.app;
 
 import info.ata4.log.LogUtils;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -132,7 +134,7 @@ public class SourceApp {
             throw new UnsupportedOperationException();
         }
 
-        if (filePatternCompiled.matcher(name.toLowerCase()).find()) {
+        if (filePatternCompiled.matcher(name.toLowerCase(Locale.ROOT)).find()) {
             L.log(Level.FINER, "File pattern match: {0} on {1}", new Object[]{filePattern, name});
             return pointsFilePattern;
         } else {

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
@@ -190,7 +190,7 @@ public class TextureSource extends ModuleRead {
 
     public String canonizeTextureName(String textureNew) {
         // convert to lower case
-        textureNew = textureNew.toLowerCase();
+        textureNew = textureNew.toLowerCase(Locale.ROOT);
 
         // fix separators
         textureNew = FilenameUtils.separatorsToUnix(textureNew);


### PR DESCRIPTION
There was a very weird issue, where when your pc language was set to Turkish you'd often end up with missing textures. For some reason, every texture name had all `i` characters converted to `?` characters. 

The source of the problem seems to be, that texture names are converted using `String.toLowerCase()`, which uses the standard locale. If this happens to be the Turkish locale, the `I` character is not converted to `i`, as you would expect from the English language, but to `ı`. [This due to the Turkish language having 2 `I` characters. The "Dotted I" (U+0069) and the "Dotles I" (U+0131).](http://www.i18nguy.com/unicode/turkish-i18n.html)
I changed the toLowerCase conversion to always use the `Locale.ROOT` locale instead of the standard one.

Fixes #51 