### PR TITLE
Feature: Add support for 'Insurgency'

### DIFF
--- a/src/main/java/info/ata4/bsplib/BspFileReader.java
+++ b/src/main/java/info/ata4/bsplib/BspFileReader.java
@@ -385,6 +385,13 @@ public class BspFileReader {
                     }
                     break;
 
+                case INSURGENCY:
+                    // Insurgency is based of the csgo engine branch so we can use DStaticPropV10CSGO
+                    if (sprpver == 10 && propStaticSize == 76) {
+                        structClass = DStaticPropV10CSGO.class;
+                    }
+                    break;
+
                 default:
                     // check for "lite" version of V11 struct in case it applies
                     // to a game other than BM (or BM wasn't detected/selected)

--- a/src/main/java/info/ata4/bsplib/app/SourceAppID.java
+++ b/src/main/java/info/ata4/bsplib/app/SourceAppID.java
@@ -35,6 +35,7 @@ public class SourceAppID {
     public static final int TITANFALL = -400;
     public static final int TEAM_FORTRESS_2 = 440;
     public static final int COUNTER_STRIKE_GO = 730;
+    public static final int INSURGENCY = 222880;
     public static final int NO_MORE_ROOM_IN_HELL = 224260;
     public static final int BLACK_MESA = 362890;
 }

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV10CSGO.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV10CSGO.java
@@ -11,6 +11,7 @@ package info.ata4.bsplib.struct;
 
 import info.ata4.io.DataReader;
 import info.ata4.io.DataWriter;
+
 import java.io.IOException;
 
 /**
@@ -37,5 +38,17 @@ public class DStaticPropV10CSGO extends DStaticPropV9 {
     public void write(DataWriter out) throws IOException {
         super.write(out);
         out.writeInt(unknown);
+    }
+
+    /**
+     * @return Always {@code false}, because DStaticPropV10CSGO doesn't use ScreenSpaceFade anymore and its flag is now used for 'RenderInFastReflection'
+     */
+    @Override
+    public boolean hasScreenSpaceFadeInPixels() {
+        return false;
+    }
+
+    public boolean hasRenderInFastReflection() {
+        return super.hasScreenSpaceFadeInPixels();
     }
 }

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -18,7 +18,8 @@ import info.ata4.bsplib.entity.KeyValue;
 import info.ata4.bsplib.nmo.NmoFile;
 import info.ata4.bsplib.struct.*;
 import info.ata4.bsplib.vector.Vector3f;
-import info.ata4.bspsrc.*;
+import info.ata4.bspsrc.BspSourceConfig;
+import info.ata4.bspsrc.VmfWriter;
 import info.ata4.bspsrc.modules.BspProtection;
 import info.ata4.bspsrc.modules.ModuleDecompile;
 import info.ata4.bspsrc.modules.VmfMeta;
@@ -36,8 +37,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static info.ata4.bsplib.app.SourceAppID.COUNTER_STRIKE_GO;
 
 /**
  * Decompiling module to write point and brush entities converted from various lumps.
@@ -630,15 +629,7 @@ public class EntitySource extends ModuleDecompile {
             writer.put("fademaxdist", pst4.fademax);
             writer.put("solid", pst4.solid);
             writer.put("model", bsp.staticPropName.get(pst4.propType));
-
-            //Csgo no longer uses the screenspacefade flag for 'Screen space fade' but for 'Render in fastreflection'
-            if (pst4.hasScreenSpaceFadeInPixels()) {
-                if (bspFile.getSourceApp().getAppID() == COUNTER_STRIKE_GO) {
-                    writer.put("drawinfastreflection", pst4.hasScreenSpaceFadeInPixels());
-                } else {
-                    writer.put("screenspacefade", pst4.hasScreenSpaceFadeInPixels());
-                }
-            }
+            writer.put("screenspacefade", pst4.hasScreenSpaceFadeInPixels());
 
             // store coordinates and targetname of the lighing origin for later
             if (pst4.usesLightingOrigin()) {
@@ -722,6 +713,10 @@ public class EntitySource extends ModuleDecompile {
                             diffMod.r, diffMod.g, diffMod.b));
                     writer.put("renderamt", diffMod.a);
                 }
+            }
+
+            if (pst instanceof DStaticPropV10CSGO) {
+                writer.put("drawinfastreflection", ((DStaticPropV10CSGO) pst).hasRenderInFastReflection());
             }
 
             if (pst instanceof DStaticPropV11CSGO) {

--- a/src/main/resources/info/ata4/bsplib/app/appdb.xml
+++ b/src/main/resources/info/ata4/bsplib/app/appdb.xml
@@ -1561,4 +1561,31 @@
             nmrih_safezone_supply
         </entities>
     </app>
+    <app name="Insurgency" id="222880">
+        <version min="21" />
+        <!-- There are more insurgency related entities, but I decided to only use distinct ones because those should be enough to detect insurgency maps -->
+        <entities>
+            ins_viewpoint
+            ins_spawnpoint
+            ins_spawnzone
+            ins_blockzone
+            trigger_capture_zone
+            point_controlpoint
+            point_flag
+            ins_rulesproxy
+            logic_push
+            logic_skirmish
+            logic_vip
+            logic_firefight
+            logic_battle
+            logic_elimination
+            logic_hunt
+            logic_checkpoint
+            logic_outpost
+            logic_training
+            obj_weapon_cache
+            obj_destructible
+            obj_destructible_vehicle
+        </entities>
+    </app>
 </apps>


### PR DESCRIPTION
## This PR adds basic support for the game [Insurgency](https://store.steampowered.com/app/222880/Insurgency/).

This includes:
- Basic detection of the game via entity type recognition.
- Support for its static prop lump

Because Insurgency is based of the csgo engine branch, it's static prop lump is identical to the one from csgo. This makes the implementation easy, because we can just reuse `DStaticPropV10CSGO`.
One fix was needed though. The change, that `screenSpaceFade` was obsoleted and replaced for `RenderInFastReflection` instead (implemented in bae568549fdd5f272b002056b4253e9a714bdef0) was only active if the actual **game** was csgo. I changed this to be always active if the `DStaticPropV10CSGO` implementation is used.


Closes #73 