### PR TITLE
Add ladder support for csgo

### DIFF
--- a/src/main/java/info/ata4/bsplib/struct/DBrush.java
+++ b/src/main/java/info/ata4/bsplib/struct/DBrush.java
@@ -10,9 +10,11 @@
 
 package info.ata4.bsplib.struct;
 
-import info.ata4.util.EnumConverter;
+import info.ata4.bsplib.app.SourceAppID;
 import info.ata4.io.DataReader;
 import info.ata4.io.DataWriter;
+import info.ata4.util.EnumConverter;
+
 import java.io.IOException;
 import java.util.Set;
 
@@ -87,6 +89,16 @@ public class DBrush implements DStruct {
 
     public boolean isCurrent90() {
         return contents.contains(BrushFlag.CONTENTS_CURRENT_90);
+    }
+
+    public boolean isFuncDetail(int appId) {
+        if (appId == SourceAppID.COUNTER_STRIKE_GO) {
+            // Note: For the game csgo, ladders can also be considered to be func_detail
+            //       even though their solid flag is always false
+            return (isSolid() || isLadder()) && isDetail();
+        } else {
+            return isSolid() && isDetail();
+        }
     }
 
     @Override

--- a/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
+++ b/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
@@ -23,6 +23,7 @@ import info.ata4.bspsrc.modules.geom.FaceSource;
 import info.ata4.bspsrc.modules.texture.TextureSource;
 import info.ata4.bspsrc.util.WindingFactory;
 import info.ata4.log.LogUtils;
+
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -179,7 +180,8 @@ public class BspDecompiler extends ModuleDecompile {
                 entsrc.writeCubemaps();
             }
 
-            if (config.writeLadders) {
+            // Only write func_ladder if game is not csgo. Cso doesn't use the func_ladder entity
+            if (config.writeLadders && bspFile.getSourceApp().getAppID() != SourceAppID.COUNTER_STRIKE_GO) {
                 entsrc.writeLadders();
             }
         }

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -407,7 +407,7 @@ public class EntitySource extends ModuleDecompile {
                 DBrush brush = bsp.brushes.get(i);
 
                 // skip non-detail/non-solid brushes
-                if (!brush.isSolid() || !brush.isDetail()) {
+                if (!brush.isFuncDetail(bspFile.getSourceApp().getAppID())) {
                     continue;
                 }
 

--- a/src/main/java/info/ata4/bspsrc/modules/geom/BrushSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/geom/BrushSource.java
@@ -11,6 +11,7 @@
 package info.ata4.bspsrc.modules.geom;
 
 import info.ata4.bsplib.BspFileReader;
+import info.ata4.bsplib.app.SourceAppID;
 import info.ata4.bsplib.struct.DBrush;
 import info.ata4.bsplib.struct.DBrushSide;
 import info.ata4.bsplib.struct.DModel;
@@ -27,11 +28,8 @@ import info.ata4.bspsrc.util.BspTreeStats;
 import info.ata4.bspsrc.util.Winding;
 import info.ata4.bspsrc.util.WindingFactory;
 import info.ata4.log.LogUtils;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -152,7 +150,7 @@ public class BrushSource extends ModuleDecompile {
             DBrush brush = bsp.brushes.get(i);
 
             // skip details
-            if (config.writeDetails && brush.isSolid() && brush.isDetail()) {
+            if (config.writeDetails && brush.isFuncDetail(bspFile.getSourceApp().getAppID())) {
                 continue;
             }
 
@@ -161,8 +159,10 @@ public class BrushSource extends ModuleDecompile {
                 continue;
             }
 
-            // skip ladders
-            if (config.writeLadders && brush.isLadder()) {
+            // only skip ladders if game not csgo
+            // csgo handles ladders as normal brushes, so we don't need to skip them here
+            if (config.writeLadders && brush.isLadder()
+                    && bspFile.getSourceApp().getAppID() != SourceAppID.COUNTER_STRIKE_GO) {
                 continue;
             }
 

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureBuilder.java
@@ -182,6 +182,11 @@ public class TextureBuilder {
                 }
             }
 
+            // In csgo a ladder isn't guaranteed to have 'isDetail()'
+            if (brush.isLadder()) {
+                return ToolTexture.INVISLADDER;
+            }
+
             // nodraw
             return ToolTexture.NODRAW;
         }


### PR DESCRIPTION
### This pull request adds support for decompiling ladders for csgo
In contrast to other games (Left 4 Dead, Cs:s, Garrys mod...), csgo doesn't use the `func_ladder` entity to create ladders but rather Vbsp automatically converts brushes with `tools/toolsinvisibleladder` material applied to ladders. More information can be found here: [https://developer.valvesoftware.com/wiki/Working_Ladders](https://developer.valvesoftware.com/wiki/Working_Ladders)
This pull request adds support for this 'non-object' brush based ladder system for csgo.

Additionally, `fixToolTexture()` now correctly reapplies `tools/toolsinvisibleladder` to all ladder brushes.