### PR TITLE
Improvments to visgroup writting

### DIFF
--- a/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
+++ b/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
@@ -16,6 +16,8 @@ import info.ata4.bspsrc.modules.entity.Camera;
 import info.ata4.log.LogUtils;
 import info.ata4.util.AlphanumComparator;
 
+import java.awt.*;
+import java.util.List;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,6 +33,8 @@ public class VmfMeta extends ModuleDecompile {
 
     // logger
     private static final Logger L = LogUtils.getLogger();
+
+    private static final Random RANDOM = new Random();
 
     // UID mappings
     private Map<Integer, Integer> faceUIDs = new HashMap<>();
@@ -215,6 +219,11 @@ public class VmfMeta extends ModuleDecompile {
 
         writer.put("name", visgroup.name);
         writer.put("visgroupid", visgroup.id);
+        writer.put("color", String.format("%s %s %s",
+                visgroup.getColor().getRed(),
+                visgroup.getColor().getBlue(),
+                visgroup.getColor().getGreen()));
+
         visgroup.visgroups.forEach(this::writeVisgroup);
 
         writer.end("visgroup");
@@ -371,6 +380,8 @@ public class VmfMeta extends ModuleDecompile {
     {
         private final String name;
         private final int id;
+        private Color color;
+
         private final Visgroup parent;
         private final SortedSet<Visgroup> visgroups = new TreeSet<>(Comparator.comparing(vg -> vg.name, AlphanumComparator.COMPARATOR));
 
@@ -382,6 +393,7 @@ public class VmfMeta extends ModuleDecompile {
             }
 
             this.name = name;
+            this.color = getNewVisgroupColor();
             this.parent = parent;
 
             if (parent != null) {
@@ -450,6 +462,16 @@ public class VmfMeta extends ModuleDecompile {
             return Stream.concat(Stream.of(this), visgroups.stream().flatMap(Visgroup::visgroupStream));
         }
 
+        public Visgroup setColor(Color color) {
+            Objects.requireNonNull(color);
+            this.color = color;
+            return this;
+        }
+
+        public Color getColor() {
+            return color;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -463,6 +485,13 @@ public class VmfMeta extends ModuleDecompile {
         @Override
         public int hashCode() {
             return id;
+        }
+
+        private Color getNewVisgroupColor() {
+            float hue = RANDOM.nextFloat();
+            float saturation = RANDOM.nextFloat() * 0.8f + 0.1f;
+            float luminance = RANDOM.nextFloat() * 0.4f + 0.5f;
+            return Color.getHSBColor(hue, saturation, luminance);
         }
     }
 

--- a/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
+++ b/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
@@ -14,10 +14,13 @@ import info.ata4.bsplib.entity.Entity;
 import info.ata4.bspsrc.VmfWriter;
 import info.ata4.bspsrc.modules.entity.Camera;
 import info.ata4.log.LogUtils;
+import info.ata4.util.AlphanumComparator;
 
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * VMF metadata control class.
@@ -40,14 +43,12 @@ public class VmfMeta extends ModuleDecompile {
     // VMF unique ID
     private int uid = 0;
 
-    // Visgroup seperator char
-    public static final char VISGROUP_SEPERATOR = '/';
-    // visgroup root node. Will not actualy be written in the final vmf but rather serves as the root node which contains every visgroup
-    private Visgroup rootVisgroup = new Visgroup("root", 0, null, new HashSet<>());
-    // number for indexing every visgroup incrementally
-    private int visgroupIndex = 1;
     // reserved visgroup ids. Main use for nmrih objectives visgroups
-    private Map<String, Integer> reservedVisgroups = new HashMap<>();
+    private Map<List<String>, Integer> reservedVisgroups = new HashMap<>();
+    // number for indexing every visgroup incrementally
+    private int visgroupIndex = 0;
+    // visgroup root node. Will not actualy be written in the final vmf but rather serves as the root node which contains every visgroup
+    private Visgroup rootVisgroup = new Visgroup("root", null);
 
     // camera list
     private List<Camera> cameras = new ArrayList<>();
@@ -206,6 +207,10 @@ public class VmfMeta extends ModuleDecompile {
     }
 
     private void writeVisgroup(Visgroup visgroup) {
+        if (!visgroup.isTreeUsed()) {
+            return;
+        }
+
         writer.start("visgroup");
 
         writer.put("name", visgroup.name);
@@ -216,97 +221,124 @@ public class VmfMeta extends ModuleDecompile {
     }
 
     public void writeMetaVisgroup(String visgroupName) {
+        writeMetaVisgroups(Collections.singletonList(rootVisgroup.getVisgroup(visgroupName)));
+    }
+
+    public void writeMetaVisgroups(List<Visgroup> visgroups) {
         writer.start("editor");
-        writer.put("visgroupid", getVisgroup(visgroupName).id);
-        writer.end("editor");
-    }
-
-    public void writeMetaVisgroups(List<String> visgroupNames) { 
-        writer.start("editor");
-        for (String visgroupName : visgroupNames) {
-            writer.put("visgroupid", getVisgroup(visgroupName).id);
-        }
-        writer.end("editor");
-    }
-
-    private Visgroup getVisgroup(String visgroupName) {
-        if (visgroupName.isEmpty())
-            throw new IllegalArgumentException("A visgroup cannot have an empty name");
-
-        Visgroup parentVisgroup = rootVisgroup;
-        for (String name : visgroupName.split(String.valueOf(VISGROUP_SEPERATOR))) {
-            parentVisgroup = getVisgroup(parentVisgroup, name);
-        }
-
-        return parentVisgroup;
-    }
-
-    private Visgroup getVisgroup(Visgroup parentVisgroup, String visgroupName) {
-        if (visgroupName.isEmpty())
-            throw new IllegalArgumentException("A visgroup cannot have an empty name");
-
-        Optional<Visgroup> optionalVisgroup = parentVisgroup.visgroups.stream()
-                .filter(visgroup -> visgroup.name.equals(visgroupName))
-                .findAny();
-
-        if (optionalVisgroup.isPresent()) {
-            return optionalVisgroup.get();
-        } else {
-            Integer visgroupId = reservedVisgroups.get(getPathForVisgroup(parentVisgroup) + VISGROUP_SEPERATOR + visgroupName);
-            if (visgroupId == null) {
-                while (reservedVisgroups.containsValue(visgroupId = visgroupIndex++));
+        for (Visgroup vg : visgroups) {
+            if (vg == rootVisgroup) {
+                throw new IllegalArgumentException("Root visgroup cannot be written");
+            }
+            if (vg.getRootVisgroup() != rootVisgroup) {
+                throw new IllegalArgumentException(String.format(
+                        "Visgroup '%s' is not part of this VmfMetas' root visgroup",
+                        String.join("/", vg.getVisgroupPath())
+                ));
             }
 
-            Visgroup targetVisgroup = new Visgroup(visgroupName, visgroupId, parentVisgroup);
-            parentVisgroup.visgroups.add(targetVisgroup);
-            return targetVisgroup;
+            writer.put("visgroupid", vg.id);
+            vg.used = true;
         }
+        writer.end("editor");
+    }
+
+    /**
+     * This method returns the root visgroup, which holds every visgroup
+     * that will be written into the final vmf.
+     * <p>Child visgroups can be created by calling {@link Visgroup#getVisgroup(String)}
+     * on the result object.
+     *
+     * @return the root visgroup
+     * @see Visgroup#getVisgroup(String)
+     */
+    public Visgroup visgroups() {
+        return rootVisgroup;
+    }
+
+    /**
+     * Returns a new visgroup id for the specified visgroup. This method either just incrementally
+     * returns a new integer or, if there exists a reseverd id for this visgroup, it returns this one.
+     *
+     * @param vg The specific visgroup, for which a new id should be created/retrieved
+     * @return a new/resevered integer id for the specified visgroup
+     */
+    private int getNewVisgroupId(Visgroup vg) {
+        return Optional.ofNullable(reservedVisgroups.get(vg.getVisgroupPath()))
+                .orElseGet(() -> IntStream.generate(() -> visgroupIndex++)
+                        .filter(id -> !reservedVisgroups.containsValue(id))
+                        .findFirst()
+                        .orElseThrow(RuntimeException::new));
+    }
+
+    /**
+     * Overloaded method for {@link #reserveVisgroupId(int, List)}
+     *
+     * @param visgroupId Integer id, the specified visgroup will use in the vmf
+     * @param visgroupNames Visgroup path which should use a specific id.
+     *                      Each element in this list correspond to a 'node' in the visgroup path.
+     *                      The first node is the root node, the second one the child of that node and so on...
+     * @throws VisgroupException if the specified id is already taken by a visgroup
+     * @see #reserveVisgroupId(int, List)
+     */
+    public void reserveVisgroupId(int visgroupId, String... visgroupNames) throws VisgroupException {
+        reserveVisgroupId(visgroupId, Arrays.asList(visgroupNames));
     }
 
     /**
      * Reserves the specified id for the specified visgroup.
-     * <p>
-     * This guarantees that the specified visgroup will use the specified id instead of a generated one.
-     * <p>
-     * <b>WARNING:</b> Any calls to this method must be made <b>before</b> any subsequent calls are made to either {@link #writeMetaVisgroup(String)} or {@link #writeMetaVisgroups(List)}. Else no guarantee can be made that the specified id can be reserved
+     * <p>This reserves the specified id to be used for the specified visgroup path.
      *
-     * @param visgroupName Visgroup name which should use a specific id. A nested visgroup can be written like "outerVisgroup + VmfMeta.VISGROUP_SEPERATOR + innerVisgroup"
-     * @param visgroupId Id, the specified visgroup will use in the vmf
+     * <p><b>WARNING:</b> Any calls to this method must be made <b>before</b> any subsequent calls are made to
+     * either {@link #writeMetaVisgroup(String)} or {@link #writeMetaVisgroups(List)}.
+     * Else no guarantee can be made that the specified id can be reserved!
+     *
+     * @param visgroupId Integer id, the specified visgroup will use in the vmf
+     * @param visgroupPath Visgroup path which should use a specific id.
+     *                     Each element in this list correspond to a 'node' in the visgroup path.
+     *                     The first node is the root node, the second one the child of that node and so on...
+     * @throws VisgroupException if the specified id is already taken by a visgroup
      */
-    public void reserveVisgroupId(String visgroupName, int visgroupId) {
-        if (visgroupName.isEmpty())
-            throw new IllegalArgumentException("A visgroup cannot have an empty name");
-
-        if (reservedVisgroups.containsValue(visgroupId)) {
-            String duplicatedVisgroupName = reservedVisgroups.entrySet().stream()
-                    .filter(entry -> entry.getValue() == visgroupId)
-                    .findAny()
-                    .map(Map.Entry::getKey)
-                    .orElse("null");
-
-            L.warning(String.format("Tried to reserve visgroup '%s' with id %d, which is already reserved by '%s'", visgroupName, visgroupId, duplicatedVisgroupName));
-            return;
+    public void reserveVisgroupId(int visgroupId, List<String> visgroupPath) throws VisgroupException {
+        if (visgroupPath.isEmpty() || visgroupPath.stream().anyMatch(String::isEmpty)) {
+            throw new IllegalArgumentException("Invalid visgroup path: " + visgroupPath);
         }
 
-        if (reservedVisgroups.containsKey(visgroupName))
-            L.warning(String.format("Visgroup '%s' is already reserved with id %d. Overriding with %d", visgroupName, reservedVisgroups.get(visgroupName), visgroupId));
+        // We add the 'root' visgroup as first element, because internally we always include it
+        // Eg: Visgroup.getVisgroupPath() always has the root visgroup as first element
+        List<String> visgroupPathFixed = new ArrayList<>(visgroupPath);
+        visgroupPathFixed.add(0, rootVisgroup.name);
 
-        reservedVisgroups.put(visgroupName, visgroupId);
-    }
-
-    /**
-     * @param visgroup A visgroup for which a path should be generated
-     * @return A String which represents path to the specified visgroup. For example for a visgroup 'InnerVis', which is in a visgroup 'OuterVis', getPathForVisgroup(InnerVis) returns "OuterVis + {@link #VISGROUP_SEPERATOR} + InnerVis"
-     */
-    private static String getPathForVisgroup(Visgroup visgroup) {
-        StringBuilder path = new StringBuilder(visgroup.name);
-
-        Visgroup parentVisgroup = visgroup;
-        while ((parentVisgroup = parentVisgroup.parent) != null && parentVisgroup.id != 0) {
-            path.insert(0, parentVisgroup.name + VISGROUP_SEPERATOR);
+        if (rootVisgroup.containsVisgroupId(visgroupId)) {
+            throw new VisgroupException(String.format("Tried to reserve already taken visgroup id %d to '%s'",
+                    visgroupId,
+                    String.join("/", visgroupPathFixed)));
         }
 
-        return path.toString();
+        // Find a duplicate with the same reserved id
+        Optional<List<String>> duplicatedVisgroupPath = reservedVisgroups.entrySet().stream()
+                .filter(entry -> entry.getValue() == visgroupId)
+                .map(Map.Entry::getKey)
+                .findAny();
+
+        if (duplicatedVisgroupPath.isPresent()) {
+            throw new VisgroupException(String.format(
+                    "Tried to reserve visgroup %s with id %d, which is already reserved by %s",
+                    String.join("/", visgroupPathFixed),
+                    visgroupId,
+                    String.join("/", duplicatedVisgroupPath.get())
+            ));
+        }
+        if (reservedVisgroups.containsKey(visgroupPathFixed)) {
+            L.warning(String.format(
+                    "Visgroup '%s' is already reserved with id %d, overwriting with %d",
+                    String.join("/", visgroupPathFixed),
+                    reservedVisgroups.get(visgroupPathFixed),
+                    visgroupId
+            ));
+        }
+
+        reservedVisgroups.put(new ArrayList<>(visgroupPathFixed), visgroupId);
     }
 
     public void writeCameras() {
@@ -333,27 +365,89 @@ public class VmfMeta extends ModuleDecompile {
     }
 
     /**
-     * Visgroup class for representing visgroups in a Tree like structure
+     * Class for representing visgroups in a tree like structure
      */
-    private static class Visgroup
+    public class Visgroup
     {
-        public String name;
-        public int id;
-        public Visgroup parent;
-        public Set<Visgroup> visgroups;
+        private final String name;
+        private final int id;
+        private final Visgroup parent;
+        private final SortedSet<Visgroup> visgroups = new TreeSet<>(Comparator.comparing(vg -> vg.name, AlphanumComparator.COMPARATOR));
 
-        public Visgroup(String name, int id, Visgroup parent) {
-            this(name, id, parent, new HashSet<>());
-        }
+        private boolean used = false;
 
-        public Visgroup(String name, int id, Visgroup parent, Set<Visgroup> visgroups) {
-            Objects.requireNonNull(name);
-            Objects.requireNonNull(visgroups);
+        private Visgroup(String name, Visgroup parent) {
+            if (name.isEmpty()) {
+                throw new IllegalArgumentException("A visgroup cannot have an empty name");
+            }
 
             this.name = name;
-            this.id = id;
             this.parent = parent;
-            this.visgroups = visgroups;
+
+            if (parent != null) {
+                parent.visgroups.add(this);
+            }
+
+            // Call last, else we might get problems because variables like 'parent' are not set
+            this.id = getNewVisgroupId(this);
+        }
+
+        /**
+         * @param visgroupName The name of the searched for visgroup
+         * @return the child visgroup of this object with the specified name.
+         */
+        public Visgroup getVisgroup(String visgroupName) {
+            if (name.isEmpty()) {
+                throw new IllegalArgumentException("A visgroup cannot have an empty name");
+            }
+
+            return visgroups.stream()
+                    .filter(visgroup -> visgroup.name.equals(visgroupName))
+                    .findAny()
+                    .orElseGet(() -> new Visgroup(visgroupName, this));
+        }
+
+        private Visgroup getRootVisgroup() {
+            Visgroup root = this;
+            while (root.parent != null) {
+                root = root.parent;
+            }
+            return root;
+        }
+
+        private List<String> getVisgroupPath() {
+            ArrayList<String> path = new ArrayList<>();
+            path.add(name);
+
+            Visgroup vg = this;
+            while ((vg = vg.parent) != null) {
+                path.add(0, vg.name);
+            }
+
+            return path;
+        }
+
+        /**
+         * @return {@code true}, if any visgroup in this tree is flag as used
+         * @see #used
+         */
+        private boolean isTreeUsed() {
+            return visgroupStream().anyMatch(vg -> vg.used);
+        }
+
+        /**
+         * @param id The specified visgroup id to test for
+         * @return {@code true}, if any visgroup, with the specified id, exist in this tree
+         */
+        private boolean containsVisgroupId(int id) {
+            return visgroupStream().anyMatch(vg -> vg.id == id);
+        }
+
+        /**
+         * @return a {@link Stream} of all visgroup objects in this tree
+         */
+        private Stream<Visgroup> visgroupStream() {
+            return Stream.concat(Stream.of(this), visgroups.stream().flatMap(Visgroup::visgroupStream));
         }
 
         @Override
@@ -361,9 +455,35 @@ public class VmfMeta extends ModuleDecompile {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            Visgroup visGroup = (Visgroup) o;
+            Visgroup visgroup = (Visgroup) o;
 
-            return id == visGroup.id;
+            return id == visgroup.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+    }
+
+    public static class VisgroupException extends Exception {
+        public VisgroupException() {
+        }
+
+        public VisgroupException(String message) {
+            super(message);
+        }
+
+        public VisgroupException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public VisgroupException(Throwable cause) {
+            super(cause);
+        }
+
+        public VisgroupException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+            super(message, cause, enableSuppression, writableStackTrace);
         }
     }
 }

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -33,6 +33,9 @@ import info.ata4.bspsrc.modules.texture.TextureSource;
 import info.ata4.bspsrc.util.*;
 import info.ata4.log.LogUtils;
 
+import java.awt.*;
+import java.util.List;
+import java.util.Queue;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -124,6 +127,28 @@ public class EntitySource extends ModuleDecompile {
         // this option is unnecessary for BSP files without instances, it will
         // only cause errors
         boolean fixRot = config.fixEntityRot && instances;
+
+        // Initialise visgroup colors
+        VmfMeta.Visgroup reallocatedVg = vmfmeta
+                .visgroups()
+                .getVisgroup("Reallocated")
+                .setColor(Color.GREEN);
+
+        VmfMeta.Visgroup rebuildVg = vmfmeta
+                .visgroups()
+                .getVisgroup("Rebuild")
+                .setColor(Color.RED);
+
+        VmfMeta.Visgroup reallocatedAreaportalVg = reallocatedVg.getVisgroup("Areaportal")
+                .setColor(Color.CYAN);
+        VmfMeta.Visgroup rebuildAreaportalVg = rebuildVg.getVisgroup("Areaportal")
+                .setColor(Color.CYAN.darker());
+
+        VmfMeta.Visgroup reallocatedOccluderVg = reallocatedVg.getVisgroup("Occluder")
+                .setColor(Color.MAGENTA);
+        VmfMeta.Visgroup rebuildOccluderVg = rebuildVg.getVisgroup("Occluder")
+                .setColor(Color.MAGENTA.darker());
+
 
         List<VmfMeta.Visgroup> visgroups = new ArrayList<>();
 
@@ -327,14 +352,10 @@ public class EntitySource extends ModuleDecompile {
                 if (isAreaportal && portalNum != -1) {
                     if (config.brushMode == BrushMode.BRUSHPLANES && apBrushMap.containsKey(portalNum)) {
                         brushsrc.writeBrush(apBrushMap.get(portalNum));
-                        visgroups.add(vmfmeta.visgroups()
-                                .getVisgroup("Reallocated")
-                                .getVisgroup("Areaportals"));
+                        visgroups.add(reallocatedAreaportalVg);
                     } else {
                         facesrc.writeAreaportal(portalNum);
-                        visgroups.add(vmfmeta.visgroups()
-                                .getVisgroup("Rebuild")
-                                .getVisgroup("Areaportals"));
+                        visgroups.add(rebuildAreaportalVg);
                     }
 
                     if (config.isDebug()) {
@@ -350,14 +371,10 @@ public class EntitySource extends ModuleDecompile {
                         for (int brushId: occBrushesMap.get(occluderNum)) {
                             brushsrc.writeBrush(brushId);
                         }
-                        visgroups.add(vmfmeta.visgroups()
-                                .getVisgroup("Reallocated")
-                                .getVisgroup("Occluders"));
+                        visgroups.add(reallocatedOccluderVg);
                     } else {
                         facesrc.writeOccluder(occluderNum);
-                        visgroups.add(vmfmeta.visgroups()
-                                .getVisgroup("Rebuild")
-                                .getVisgroup("Occluders"));
+                        visgroups.add(rebuildOccluderVg);
                     }
                 }
             }

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -275,12 +275,16 @@ public class AreaportalMapper {
             writer.start("entity");
             writer.put("id", vmfMeta.getUID());
             writer.put("classname", "func_detail");
-            writer.put("areaportalIDs", areaportalHelper.portalID.stream().map(Object::toString).collect(Collectors.joining(", ")));
+            writer.put("areaportalIDs", areaportalHelper.portalID.stream()
+                    .map(Object::toString)
+                    .collect(Collectors.joining(", ")));
 
             faceSource.writePolygon(areaportalHelper.winding, ToolTexture.SKIP, true);
             vmfMeta.writeMetaVisgroups(
                     areaportalHelper.portalID.stream()
-                            .map(id -> "AreaportalID" + VmfMeta.VISGROUP_SEPERATOR +  id)
+                            .map(id -> vmfMeta.visgroups()
+                                    .getVisgroup("AreaportalID")
+                                    .getVisgroup(String.valueOf(id)))
                             .collect(Collectors.toList())
             );
 

--- a/src/main/java/info/ata4/util/AlphanumComparator.java
+++ b/src/main/java/info/ata4/util/AlphanumComparator.java
@@ -1,0 +1,116 @@
+package info.ata4.util;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Comparator to sort strings by a more 'human logic'
+ */
+public class AlphanumComparator implements Comparator<String> {
+
+    private static final Pattern CHUNK_PATTERN = Pattern.compile("\\D+|\\d+");
+    private static final Pattern LEADING_ZERO_PATTERN = Pattern.compile("^0*");
+
+    public static final Comparator<String> COMPARATOR = Comparator.nullsFirst(AlphanumComparator::compareInternal);
+
+    @Override
+    public int compare(String s1, String s2) {
+        return COMPARATOR.compare(s1, s2);
+    }
+
+    private static int compareInternal(String s1, String s2) {
+        ChunkIterator s1Iterator = new ChunkIterator(s1);
+        ChunkIterator s2Iterator = new ChunkIterator(s2);
+
+        while (s1Iterator.hasNext() && s2Iterator.hasNext()) {
+            String s1Chunk = s1Iterator.next();
+            String s2Chunk = s2Iterator.next();
+
+            int result;
+            if (Character.isDigit(s1Chunk.charAt(0)) && Character.isDigit(s2Chunk.charAt(0))) {
+                result = compareNumber(s1Chunk, s2Chunk);
+            } else {
+                result = s1Chunk.compareTo(s2Chunk);
+            }
+
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        return s1Iterator.hasNext() ? 1 : 0;
+    }
+
+    // Could be improved. Doesn't account for negative numbers for example
+    private static int compareNumber(String s1, String s2) {
+        Matcher m1 = LEADING_ZERO_PATTERN.matcher(s1);
+        Matcher m2 = LEADING_ZERO_PATTERN.matcher(s2);
+
+        String trimS1 = m1.replaceFirst("");
+        String trimS2 = m2.replaceFirst("");
+
+        int trimmedZeros1 = s1.length() - trimS1.length();
+        int trimmedZeros2 = s2.length() - trimS2.length();
+
+        int result = trimmedZeros2 - trimmedZeros1;
+        if (result != 0) {
+            return result;
+        }
+
+        return compareNumber(trimS1, trimS2, trimmedZeros1 + trimmedZeros2 > 0);
+    }
+
+    private static int compareNumber(String s1, String s2, boolean leadingZero) {
+        if (!leadingZero) {
+            int result = s1.length() - s2.length();
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        for (int i = 0; i < Math.min(s1.length(), s2.length()); i++) {
+            int result = Character.getNumericValue(s1.charAt(i)) - Character.getNumericValue(s2.charAt(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        return 0;
+    }
+
+    private static class ChunkIterator implements Iterator<String> {
+
+        private final Matcher m;
+
+        private String nextResult;
+
+        public ChunkIterator(String s) {
+            m = CHUNK_PATTERN.matcher(s);
+
+            nextResult = newResult();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return nextResult != null;
+        }
+
+        @Override
+        public String next() {
+            if (nextResult == null) {
+                throw new NoSuchElementException();
+            }
+
+            String result = nextResult;
+            nextResult = newResult();
+            return result;
+        }
+
+        private String newResult() {
+            return m.find() ? m.group() : null;
+        }
+    }
+}


### PR DESCRIPTION
## This PR adds several improvements to the Visgroup writing process.
This includes:
- Sorting visgroups by their name for better readability.
- Support for visgroup colors.
- Unused visgroups are no longer written to the vmf

### Visgroup sorting
Visgroups are now sorted by their name using a custom String Comparator. It's called `AlphanumComparator` and tries to create a more 'human-like' sorting algorithm by separating a string into multiple chunks. A chunk can either be a digit or just a normal string. This makes it possible to compare digits by their literal value.

**Comparison of de_inferno from csgo:**

| No sorting | String Comparator| Alphanum Comparator  |
| --- | --- | --- |
| ![no-sorting](https://user-images.githubusercontent.com/19492038/70857297-08faf100-1eec-11ea-85f1-779c79419baa.PNG) | ![normal](https://user-images.githubusercontent.com/19492038/70857394-b0c4ee80-1eed-11ea-8d0e-6b5cef76df78.PNG) | ![alphanum](https://user-images.githubusercontent.com/19492038/70857395-b6bacf80-1eed-11ea-9cfb-eaf708c7ae34.PNG) |

### Visgroup colors
Visgroups now support colors. Previously no color information was written with visgroups, causing them to appear in black. Now, a visgroups color can be either set by calling its 'setColor' method or a random one will be generated.

### Unused visgroups are no longer written
Even though hammer really likes removing empty visgroups, we now make sure that any unused visgroup is not written to the vmf.
