### PR TITLE
Update JDK and Apache Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <repositories>
@@ -66,12 +64,12 @@
     </dependencies>
 
     <build>
-        <!-- Create fat jar using Maven Shade -->
         <plugins>
+            <!-- Create fat jar using Maven Shade -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -91,9 +89,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <showDeprecation>true</showDeprecation>
+                    <release>8</release>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
In order to use JDK 9 or later for compiling bspsrc, but still compile for Java 8, the Apache Maven Compiler Plugin has been configured to use the '--release' command-line option instead of '-source' and '-target' with javac. This ensures that the compiled program will not accidentally use APIs that are only available in the Java version corresponding to the JDK in use.

The Apache Maven Compiler Plugin and the Apache Maven Shade Plugin have also been updated to their current versions.

Fixes #83 