### PR TITLE
Fix exception with invalid areaportal/occluder data

### DIFF
--- a/src/main/java/info/ata4/bsplib/util/VectorUtil.java
+++ b/src/main/java/info/ata4/bsplib/util/VectorUtil.java
@@ -16,27 +16,36 @@ public class VectorUtil {
 		DPlane occluderPlane = bsp.planes.get(occluderPolyData.planenum);
 		DPlane brushSidePlane = bsp.planes.get(brushSide.pnum);
 
-		if (shareSamePlane(occluderPlane, brushSidePlane))
-			return internalMatchingAreaPercentage(WindingFactory.fromOccluder(bsp, occluderPolyData), WindingFactory.fromSide(bsp, brush, brushSide));
-		else
+		if (shareSamePlane(occluderPlane, brushSidePlane)) {
+			return internalMatchingAreaPercentage(
+					WindingFactory.fromOccluder(bsp, occluderPolyData).removeDegenerated(),
+					WindingFactory.fromSide(bsp, brush, brushSide).removeDegenerated()
+			);
+		} else {
 			return 0;
+		}
 	}
 
 	public static double matchingAreaPercentage(DAreaportal areaportal, DBrush brush, DBrushSide brushSide, BspData bsp) {
-
 		DPlane areaportalPlane = bsp.planes.get(areaportal.planenum);
 		DPlane brushSidePlane = bsp.planes.get(brushSide.pnum);
 
-		if (shareSamePlane(areaportalPlane, brushSidePlane))
-			return internalMatchingAreaPercentage(WindingFactory.fromAreaportal(bsp, areaportal), WindingFactory.fromSide(bsp, brush, brushSide));
-		else
+		if (shareSamePlane(areaportalPlane, brushSidePlane)) {
+			return internalMatchingAreaPercentage(
+					WindingFactory.fromAreaportal(bsp, areaportal).removeDegenerated(),
+					WindingFactory.fromSide(bsp, brush, brushSide).removeDegenerated()
+			);
+		} else {
 			return 0;
+		}
 	}
 
 	public static boolean shareSamePlane(DPlane p1, DPlane p2) {
+		//TODO: PLEASE, CAN SOMEONE WITH ACTUAL KNOWLEDGE REPLACE THIS CODE? I CAN'T LOOK AT IT ANY LONGER
 		//TODO: I have no idea how you would actually mathematically compute the error margin, so im just using a guessed one here (0.001)
 		//TODO: Maybe remove 'EPS_DEGEN'. I have no idea if this is needed here or how you should even use it
-		return p1.normal.normalize().cross(p2.normal.normalize()).length() < 0.001 && Math.abs(p1.dist - p2.dist * (p1.normal.dot(p2.normal) >= 1 ? 1 : -1)) < Winding.EPS_DEGEN;
+		return p1.normal.normalize().cross(p2.normal.normalize()).length() < 0.001
+				&& Math.abs(p1.dist - p2.dist * (p1.normal.dot(p2.normal) >= 1 ? 1 : -1)) < Winding.EPS_DEGEN;
 	}
 
 	/**
@@ -48,6 +57,10 @@ public class VectorUtil {
 	 * @return A probability in form of a double ranging from 0 to 1
 	 */
 	private static double internalMatchingAreaPercentage(Winding w1, Winding w2) {
+		// In case the provided windings are invalid, return 0!
+		if (w1.size() < 3 || w2.size() < 3 || w1.isHuge() || w2.isHuge())
+			return 0;
+
 		Vector3f[] plane = w1.buildPlane();
 		Vector3f vec1 = plane[1].sub(plane[0]);
 		Vector3f vec2 = plane[2].sub(plane[0]);

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -224,24 +224,36 @@ public class EntitySource extends ModuleDecompile {
             if (isAreaportal) {
                 String portalNumString = ent.getValue("portalnumber");
 
-                // extract portal number
-                if (portalNumString != null) {
-                    try {
-                        portalNum = Integer.valueOf(portalNumString);
-                    } catch (NumberFormatException ex) {
-                        portalNum = -1;
-                    }
+                if (portalNumString == null) {
+                    L.warning(String.format(
+                            "%s is missing 'portalnumber' attribute, skipping...",
+                            className
+                    ));
+                    continue;
+                }
 
-                    int finalPortalNum = portalNum;
-                    if (bsp.areaportals.stream().noneMatch(areaportal -> areaportal.portalKey == finalPortalNum)) {
-                        L.warning("funct_areaportal entity links to a non existing areaportal, skipping...");
-                        continue;
-                    }
+                try {
+                    portalNum = Integer.parseInt(portalNumString);
+                } catch (NumberFormatException e) {
+                    L.warning(String.format(
+                            "Can't parse %s 'portalnumber' attribute: '%s', skipping...",
+                            className,
+                            portalNumString
+                    ));
+                    continue;
+                }
 
-                    // keep the number when debugging
-                    if (!config.isDebug()) {
-                        ent.removeValue("portalnumber");
-                    }
+                if (!areaportalMapper.hasValidGeometry(portalNum)) {
+                    L.warning(String.format(
+                            "%s links to non existing areaportal or has invalid geometry, skipping...",
+                            className
+                    ));
+                    continue;
+                }
+
+                // keep the number when debugging
+                if (!config.isDebug()) {
+                    ent.removeValue("portalnumber");
                 }
             }
 
@@ -250,18 +262,28 @@ public class EntitySource extends ModuleDecompile {
             if (isOccluder) {
                 String occluderNumString = ent.getValue("occludernumber");
 
-                // extract occluder number
-                if (occluderNumString != null) {
-                    try {
-                        occluderNum = Integer.valueOf(occluderNumString);
-                    } catch (NumberFormatException ex) {
-                        occluderNum = -1;
-                    }
+                if (occluderNumString == null) {
+                    L.warning(String.format(
+                            "%s is missing 'occludernumber' attribute, skipping...",
+                            className
+                    ));
+                    continue;
+                }
 
-                    // keep the number when debugging
-                    if (!config.isDebug()) {
-                        ent.removeValue("occludernumber");
-                    }
+                try {
+                    occluderNum = Integer.parseInt(occluderNumString);
+                } catch (NumberFormatException ex) {
+                    L.warning(String.format(
+                            "Can't parse %s 'occludernumber' attribute: '%s', skipping...",
+                            className,
+                            occluderNumString
+                    ));
+                    continue;
+                }
+
+                // keep the number when debugging
+                if (!config.isDebug()) {
+                    ent.removeValue("occludernumber");
                 }
             }
 

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -96,6 +96,12 @@ public class AreaportalMapper {
                 .collect(Collectors.toList()));
     }
 
+    public boolean hasValidGeometry(int portalId) {
+        return areaportalHelpers.stream()
+                .filter(apHelper -> !apHelper.winding.isEmpty())
+                .anyMatch(apHelper -> apHelper.portalID.contains(portalId));
+    }
+
     /**
      * Maps areaportal brushes to the likeliest areaportal entity it represents
      * <p></p>


### PR DESCRIPTION
Previously the decompiler crashed, when calling `VectorUtil.internalMatchingAreaPercentage` with an invalid Winding. This was because the method made the assumption, that the provided windings at least contained 3 vertices.

This pr adds a check to that method, returning 0 in cases where the provided windings are invalid.
Additionally error handling with areaportal and occluder writing was improved.

Fixes #85