### PR TITLE
Fix NoSuchElementException when reallocating areaportals of certain maps

### DIFF
--- a/src/main/java/info/ata4/bsplib/util/VectorUtil.java
+++ b/src/main/java/info/ata4/bsplib/util/VectorUtil.java
@@ -90,17 +90,21 @@ public class VectorUtil {
 		List<Vector2f> intersectionPolygon = VectorUtil.orderVertices(intersectingVertices);
 
 		double intersectionArea = VectorUtil.polygonArea(intersectionPolygon);
+		// error margin
+		if (intersectionArea < 1)
+			intersectionArea = 0;
+
 		double w1Area = VectorUtil.polygonArea(w1Polygon);
 
-		// actually intersectionArea / w1Area should never be greater 1, but i don't know why I have written that, so im just gonna leave that here
-		return intersectionArea / w1Area > 1 ? 0 : Math.abs(intersectionArea / w1Area);
+		return Math.min(intersectionArea / w1Area, 1);
 	}
 
 	//https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
 	public static boolean isInsideConvexPolygon(Vector2f p, List<Vector2f> polygon) {
 		return IntStream.range(0, polygon.size())
 				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
-				.filter(edge -> (edge[0].y > p.y) != (edge[1].y > p.y) && (p.x < (edge[1].x - edge[0].x) * (p.y - edge[0].y) / (edge[1].y - edge[0].y) + edge[0].x))
+				.filter(edge -> (edge[0].y > p.y) != (edge[1].y > p.y)
+						&& (p.x < (edge[1].x - edge[0].x) * (p.y - edge[0].y) / (edge[1].y - edge[0].y) + edge[0].x))
 				.limit(2)
 				.count() % 2 == 1;
 	}
@@ -141,10 +145,10 @@ public class VectorUtil {
 	}
 
 	public static double polygonArea(List<Vector2f> polygon) {
-		return IntStream.range(0, polygon.size())
+		return Math.abs(IntStream.range(0, polygon.size())
 				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
 				.mapToDouble(edge -> (edge[0].x + edge[1].x) * (edge[0].y - edge[1].y))
-				.sum() / 2;
+				.sum() / 2);
 	}
 
 	public static List<Vector2f> orderVertices(Collection<Vector2f> vertices) {

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -278,15 +278,15 @@ public class AreaportalMapper {
     }
 
     private Map<Integer, Integer> orderedMapping() {
-        int areaportalIDCount = areaportalHelpers.stream()
-                .mapToInt(apHelper -> apHelper.portalID.size())
-                .sum();
-
         int areaportalBrushCount = areaportalBrushes.size();
+        List<Integer> areaportalIds = areaportalHelpers.stream()
+                .flatMap(areaportalHelper -> areaportalHelper.portalID.stream())
+                .sorted()
+                .collect(Collectors.toList());
 
-        return IntStream.range(0, Math.min(areaportalIDCount, areaportalBrushCount))
+        return IntStream.range(0, Math.min(areaportalIds.size(), areaportalBrushCount))
                 .boxed()
-                .collect(Collectors.toMap(i -> i + 1, i -> bsp.brushes.indexOf(areaportalBrushes.get(i))));
+                .collect(Collectors.toMap(areaportalIds::get, i -> bsp.brushes.indexOf(areaportalBrushes.get(i))));
     }
 
 

--- a/src/main/java/info/ata4/util/JavaUtil.java
+++ b/src/main/java/info/ata4/util/JavaUtil.java
@@ -1,0 +1,16 @@
+package info.ata4.util;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Util helper class for methods that got introduced in jdk9+ but can't be
+ * utilized because the project is compiled for jdk 8
+ */
+public class JavaUtil {
+    public static <T> Stream<T> streamOpt(Optional<T> optional) {
+        return optional
+                .map(Stream::of)
+                .orElseGet(Stream::empty);
+    }
+}


### PR DESCRIPTION
This pr fixes a `NoSuchElementException` sometimes being thrown in the `Manual` areaportal reallocating method.
Additionally, some changes were also made to the `Ordered` mode, to make it a little more robust.
Fixes: #88 