### PR TITLE
Add support for lzma zip compression method (14)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
         <!-- Dependencies from jitpack.io -->
         <dependency>
             <groupId>com.github.ata4</groupId>
-            <artifactId>lzmajio</artifactId>
-            <version>3a3e05009e</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.ata4</groupId>
             <artifactId>ioutils</artifactId>
             <version>b1f26588b5</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,13 @@
             <version>1.4</version>
         </dependency>
 
+        <!-- 'xz for java' required for common-compress lzma -->
+        <dependency>
+            <groupId>org.tukaani</groupId>
+            <artifactId>xz</artifactId>
+            <version>1.8</version>
+        </dependency>
+
         <!-- Dependencies from jitpack.io -->
         <dependency>
             <groupId>com.github.ata4</groupId>

--- a/src/main/java/info/ata4/bspinfo/gui/BspInfoFrame.java
+++ b/src/main/java/info/ata4/bspinfo/gui/BspInfoFrame.java
@@ -16,7 +16,6 @@ import info.ata4.bspinfo.gui.models.LumpTableModel;
 import info.ata4.bsplib.BspFile;
 import info.ata4.bsplib.BspFileFilter;
 import info.ata4.bsplib.BspFileReader;
-import info.ata4.bsplib.PakFile;
 import info.ata4.bsplib.app.SourceApp;
 import info.ata4.bsplib.entity.Entity;
 import info.ata4.bsplib.lump.LumpType;
@@ -1325,7 +1324,7 @@ public class BspInfoFrame extends javax.swing.JFrame {
         }
 
         try {
-            bspFile.getPakFile().unpack(dest.toPath(), PakFile.nameFilter(names));
+            bspFile.getPakFile().unpack(dest.toPath(), names::contains);
 
             JOptionPane.showMessageDialog(this, "Successfully extracted " + names.size() + " embedded files.");
         } catch (IOException ex) {

--- a/src/main/java/info/ata4/bspinfo/gui/models/EmbeddedTableModel.java
+++ b/src/main/java/info/ata4/bspinfo/gui/models/EmbeddedTableModel.java
@@ -12,14 +12,14 @@ package info.ata4.bspinfo.gui.models;
 import info.ata4.bsplib.BspFile;
 import info.ata4.log.LogUtils;
 import info.ata4.util.gui.ListTableModel;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Enumeration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 
 /**
  *
@@ -38,13 +38,11 @@ public class EmbeddedTableModel extends ListTableModel {
     public EmbeddedTableModel(BspFile bspFile) {
         this();
 
-        try (ZipArchiveInputStream zis = bspFile.getPakFile().getArchiveInputStream()) {
-            ZipArchiveEntry ze;
-            while ((ze = zis.getNextZipEntry()) != null) {
-                List<Object> row = new ArrayList<>();
-                row.add(ze.getName());
-                row.add(ze.getSize());
-                addRow(row);
+        try (ZipFile zip = bspFile.getPakFile().getZipFile()) {
+            Enumeration<ZipArchiveEntry> enumeration = zip.getEntries();
+            while (enumeration.hasMoreElements()) {
+                ZipArchiveEntry ze = enumeration.nextElement();
+                addRow(Arrays.asList(ze.getName(), ze.getSize()));
             }
         } catch (IOException ex) {
             L.log(Level.WARNING, "Can't read pak");

--- a/src/main/java/info/ata4/bsplib/BspFile.java
+++ b/src/main/java/info/ata4/bsplib/BspFile.java
@@ -13,7 +13,7 @@ package info.ata4.bsplib;
 import info.ata4.bsplib.app.SourceApp;
 import info.ata4.bsplib.app.SourceAppDB;
 import static info.ata4.bsplib.app.SourceAppID.*;
-import info.ata4.bsplib.io.LzmaBuffer;
+import info.ata4.bsplib.io.LzmaUtil;
 import info.ata4.bsplib.lump.*;
 import info.ata4.bsplib.util.StringMacroUtils;
 import info.ata4.io.DataReader;
@@ -791,7 +791,7 @@ public class BspFile {
             }
 
             // don't compress if the result will always be bigger than uncompressed
-            if (l.getLength() <= LzmaBuffer.HEADER_SIZE) {
+            if (l.getLength() <= LzmaUtil.HEADER_SIZE) {
                 continue;
             }
 
@@ -803,7 +803,7 @@ public class BspFile {
 
         for (GameLump gl : gameLumps) {
             // don't compress if the result will always be bigger than uncompressed
-            if (gl.getLength() <= LzmaBuffer.HEADER_SIZE) {
+            if (gl.getLength() <= LzmaUtil.HEADER_SIZE) {
                 continue;
             }
 

--- a/src/main/java/info/ata4/bsplib/PakFile.java
+++ b/src/main/java/info/ata4/bsplib/PakFile.java
@@ -84,7 +84,7 @@ public class PakFile {
                 // create file path for zip entry and canonize it
                 Path entryFile = dest.resolve(entryName).normalize();
 
-                // don't allow file path to exit the extraction directory
+                // don't allow file path to exit outside the extraction directory
                 if (!entryFile.startsWith(dest)) {
                     L.log(Level.WARNING, "Skipped {0} (path traversal attempt)", entryName);
                     continue;

--- a/src/main/java/info/ata4/bsplib/PakFile.java
+++ b/src/main/java/info/ata4/bsplib/PakFile.java
@@ -150,8 +150,8 @@ public class PakFile {
     public static boolean isVBSPGeneratedFile(String bspFileName, String embeddedFileName) {
         return TextureSource
                 .isPatchedMaterial(bspFileName)
-                .or(fileName -> vhvPattern.matcher(fileName).matches()
-                        || cubemapVtfPattern.matcher(fileName).matches()
+                .or(fileName -> vhvPattern.matcher(fileName).find()
+                        || cubemapVtfPattern.matcher(fileName).find()
                         || fileName.equalsIgnoreCase("cubemapdefault.vtf")
                         || fileName.equalsIgnoreCase("cubemapdefault.hdr.vtf"))
                 .test(embeddedFileName);

--- a/src/main/java/info/ata4/bsplib/lump/AbstractLump.java
+++ b/src/main/java/info/ata4/bsplib/lump/AbstractLump.java
@@ -10,7 +10,7 @@
 
 package info.ata4.bsplib.lump;
 
-import info.ata4.bsplib.io.LzmaBuffer;
+import info.ata4.bsplib.io.LzmaUtil;
 import info.ata4.io.buffer.ByteBufferInputStream;
 import info.ata4.io.buffer.ByteBufferOutputStream;
 import info.ata4.log.LogUtils;
@@ -66,7 +66,7 @@ public abstract class AbstractLump {
     public void setBuffer(ByteBuffer buf) {
         buffer = buf;
         buffer.rewind();
-        setCompressed(LzmaBuffer.isCompressed(buffer));
+        setCompressed(LzmaUtil.isCompressed(buffer));
     }
 
     public InputStream getInputStream() {
@@ -107,7 +107,7 @@ public abstract class AbstractLump {
         }
 
         try {
-            buffer = LzmaBuffer.compress(buffer);
+            buffer = LzmaUtil.compress(buffer);
         } catch (IOException ex) {
             L.log(Level.SEVERE, "Couldn't compress lump " + this, ex);
         }
@@ -121,7 +121,7 @@ public abstract class AbstractLump {
         }
 
         try {
-            buffer = LzmaBuffer.uncompress(buffer);
+            buffer = LzmaUtil.uncompress(buffer);
         } catch (IOException ex) {
             L.log(Level.SEVERE, "Couldn't uncompress lump " + this, ex);
         }

--- a/src/main/java/info/ata4/bspsrc/BspSource.java
+++ b/src/main/java/info/ata4/bspsrc/BspSource.java
@@ -113,7 +113,10 @@ public class BspSource implements Runnable {
             // extract embedded files
             if (config.unpackEmbedded) {
                 try {
-                    bsp.getPakFile().unpack(entry.getPakDir().toPath(), path -> !config.smartUnpack || !PakFile.isVBSPGeneratedFile(bsp.getName()).test(path));
+                    bsp.getPakFile().unpack(
+                            entry.getPakDir().toPath(),
+                            fileName -> !config.smartUnpack || !PakFile.isVBSPGeneratedFile(bsp.getName(), fileName)
+                    );
                 } catch (IOException ex) {
                     L.log(Level.WARNING, "Can't extract embedded files", ex);
                 }

--- a/src/main/java/info/ata4/bspsrc/modules/BspCompileParams.java
+++ b/src/main/java/info/ata4/bspsrc/modules/BspCompileParams.java
@@ -13,14 +13,16 @@ import info.ata4.bsplib.BspFileReader;
 import info.ata4.bsplib.lump.LumpType;
 import info.ata4.bsplib.struct.LevelFlag;
 import info.ata4.log.LogUtils;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 
 /**
  *
@@ -45,9 +47,11 @@ public class BspCompileParams extends ModuleRead {
         boolean stale = false;
         boolean hasVhv = false;
 
-        try (ZipArchiveInputStream zis = bspFile.getPakFile().getArchiveInputStream()) {
-            ZipArchiveEntry ze;
-            while ((ze = zis.getNextZipEntry()) != null) {
+        try (ZipFile zip = bspFile.getPakFile().getZipFile()) {
+            Enumeration<ZipArchiveEntry> enumeration = zip.getEntries();
+            while (enumeration.hasMoreElements()) {
+                ZipArchiveEntry ze = enumeration.nextElement();
+
                 // check for stale.txt, which marks possibly screwed up maps
                 if (ze.getName().equals("stale.txt")) {
                     stale = true;

--- a/src/main/java/info/ata4/bspsrc/modules/BspProtection.java
+++ b/src/main/java/info/ata4/bspsrc/modules/BspProtection.java
@@ -16,19 +16,17 @@ import info.ata4.bsplib.struct.DBrush;
 import info.ata4.bsplib.struct.DBrushSide;
 import info.ata4.bsplib.struct.DPlane;
 import info.ata4.bsplib.vector.Vector3f;
+import info.ata4.bspsrc.modules.geom.BrushUtils;
 import info.ata4.bspsrc.modules.texture.TextureSource;
 import info.ata4.bspsrc.modules.texture.ToolTexture;
-import info.ata4.bspsrc.util.AABB;
-import info.ata4.bspsrc.modules.geom.BrushUtils;
-import info.ata4.bspsrc.util.WindingFactory;
 import info.ata4.log.LogUtils;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 
 /**
  * A module to check if the map has been protected by the mapper with at least
@@ -344,14 +342,10 @@ public class BspProtection extends ModuleRead {
             return;
         }
 
-        try (ZipArchiveInputStream zis = bspFile.getPakFile().getArchiveInputStream()) {
-            ZipArchiveEntry ze;
-            while ((ze = zis.getNextZipEntry()) != null) {
-                if (ze.getName().equals(BSPPROTECT_FILE)) {
-                    L.fine("Found encrypted entities!");
-                    encryptedEnt = true;
-                    break;
-                }
+        try (ZipFile zip = bspFile.getPakFile().getZipFile()) {
+            if (zip.getEntries(BSPPROTECT_FILE).iterator().hasNext()) {
+                L.fine("Found encrypted entities!");
+                encryptedEnt = true;
             }
         } catch (IOException ex) {
             L.log(Level.WARNING, "Couldn't read pakfile", ex);

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
@@ -15,7 +15,6 @@ import info.ata4.bspsrc.modules.ModuleRead;
 import info.ata4.log.LogUtils;
 import org.apache.commons.io.FilenameUtils;
 
-import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -232,14 +231,13 @@ public class TextureSource extends ModuleRead {
         return Pattern.compile(String.format("maps/%s/(?<%s>.+)_depth_-?\\d+", bspFileName, CONTENT_GROUP));
     }
 
-    public static Predicate<Path> isPatchedMaterial(String bspFileName) {
+    public static Predicate<String> isPatchedMaterial(String bspFileName) {
         Pattern originPattern = compileOriginPattern(bspFileName);
         Pattern wvtPatchPattern = compileWvtPatchPattern(bspFileName);
         Pattern waterPatchPattern = compileWaterPatchPattern(bspFileName);
 
-
-        return path -> {
-            String canonizedName = canonizeTextureName(path.toString());
+        return fileName -> {
+            String canonizedName = canonizeTextureName(fileName);
             return originPattern.matcher(canonizedName).find()
                         || wvtPatchPattern.matcher(canonizedName).find()
                         || waterPatchPattern.matcher(canonizedName).find();

--- a/src/main/java/info/ata4/bspunprotect/BspUnprotect.java
+++ b/src/main/java/info/ata4/bspunprotect/BspUnprotect.java
@@ -14,16 +14,17 @@ import info.ata4.bsplib.BspFile;
 import info.ata4.bsplib.lump.Lump;
 import info.ata4.bsplib.lump.LumpFile;
 import info.ata4.bsplib.lump.LumpType;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.io.IOUtils;
+
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-import org.apache.commons.io.IOUtils;
+import java.util.Iterator;
 
 /**
  * BSPProtect map decrypter.
@@ -154,16 +155,11 @@ public class BspUnprotect {
     }
 
     private byte[] readEncryptedEntities() {
-        try (ZipArchiveInputStream zis = bspFile.getPakFile().getArchiveInputStream()) {
-            ZipArchiveEntry ze;
-
-            while ((ze = zis.getNextZipEntry()) != null) {
-                if (ze.getName().equals(BSPPROTECT_FILE)) {
-                    ByteArrayOutputStream os = new ByteArrayOutputStream();
-                    IOUtils.copy(zis, os);
-                    return os.toByteArray();
-                }
-            }  
+        try (ZipFile zip = bspFile.getPakFile().getZipFile()) {
+            Iterator<ZipArchiveEntry> iterator = zip.getEntries(BSPPROTECT_FILE).iterator();
+            if (iterator.hasNext()) {
+                return IOUtils.toByteArray(zip.getInputStream(iterator.next()));
+            }
         } catch (IOException ex) {
             throw new RuntimeException("Couldn't read pakfile", ex);
         }


### PR DESCRIPTION
Extracting of embedded resources is currently handled by Apache Commons Compress, which however doesn't support the zip compression method 14 (lzma). This compression method is used in games like Team Fortress 2. The pull request manually adds support for that compression method.

Important to note is, that I switched the lzma decompressing library from [ata4/lzmajio](https://github.com/ata4/lzmajio) to another one called [xz for java](https://tukaani.org/xz/java.html) (also used by common compress for lzma file compression/decompression). I made this change because `xz for java` has a better support for lzma input/output streams, which I needed. It is, however, entirely possible to implement the current code with the old library `ata4/lzmajio`, so if that needed, I could make the required changes.

I've tested my changes on Team Fortress 2, which uses the zip lzma compression method, as well as lzma compressed lumps and had no problem what so ever.

Additionally, I've fixed I minor bug with 'smart extracting' (3017206).

Fixes #78, #31
