### PR TITLE
Add support for Vindictus sprp version 7

### DIFF
--- a/src/main/java/info/ata4/bsplib/BspFileReader.java
+++ b/src/main/java/info/ata4/bsplib/BspFileReader.java
@@ -290,7 +290,7 @@ public class BspFileReader {
 
             HashMap<Integer, Vector3f> scaling = new HashMap<>();
             // extra data for Vindictus
-            if (appID == VINDICTUS && sprpver == 6) {
+            if (appID == VINDICTUS && sprpver > 5) {
                 int scalingCount = in.readInt();
                 for (int i = 0; i < scalingCount; i++) {
                     scaling.put(in.readInt(), Vector3f.read(in));
@@ -344,10 +344,13 @@ public class BspFileReader {
                     break;
 
                 case VINDICTUS:
-                    // newer maps report v6 even though the size is still 60, probably because they additionally have a
-                    // scaling attribute which however is not saved in the actual prop itself
+                    // newer maps report v6 even though their structure is identical to DStaticPropV5, probably because
+                    // they additional have scaling array saved before the static prop array
+                    // Consequently, their v7 seems to be a standard DStaticPropV6 with an additional scaling array
                     if (sprpver == 6 && propStaticSize == 60) {
                         structClass = DStaticPropV6VIN.class;
+                    } else if (sprpver == 7 && propStaticSize == 64) {
+                        structClass = DStaticPropV7VIN.class;
                     }
                     break;
 
@@ -450,8 +453,8 @@ public class BspFileReader {
                     in.seek(numFillBytes, CURRENT);
                 }
 
-                if (scaling.containsKey(i) && sp instanceof DStaticPropV6VIN)
-                    ((DStaticPropV6VIN) sp).scaling = scaling.get(i);
+                if (scaling.containsKey(i) && sp instanceof DStaticPropVinScaling)
+                    ((DStaticPropVinScaling) sp).setScaling(scaling.get(i));
 
                 bspData.staticProps.add(sp);
             }

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV6VIN.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV6VIN.java
@@ -2,6 +2,8 @@ package info.ata4.bsplib.struct;
 
 import info.ata4.bsplib.vector.Vector3f;
 
+import java.util.Objects;
+
 public class DStaticPropV6VIN extends DStaticPropV5 implements DStaticPropVinScaling {
 
     public Vector3f scaling = new Vector3f(1, 1, 1);
@@ -13,6 +15,6 @@ public class DStaticPropV6VIN extends DStaticPropV5 implements DStaticPropVinSca
 
     @Override
     public void setScaling(Vector3f scaling) {
-        this.scaling = scaling;
+        this.scaling = Objects.requireNonNull(scaling);
     }
 }

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV6VIN.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV6VIN.java
@@ -2,7 +2,17 @@ package info.ata4.bsplib.struct;
 
 import info.ata4.bsplib.vector.Vector3f;
 
-public class DStaticPropV6VIN extends DStaticPropV5 {
+public class DStaticPropV6VIN extends DStaticPropV5 implements DStaticPropVinScaling {
 
     public Vector3f scaling = new Vector3f(1, 1, 1);
+
+    @Override
+    public Vector3f getScaling() {
+        return scaling;
+    }
+
+    @Override
+    public void setScaling(Vector3f scaling) {
+        this.scaling = scaling;
+    }
 }

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV7VIN.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV7VIN.java
@@ -1,0 +1,18 @@
+package info.ata4.bsplib.struct;
+
+import info.ata4.bsplib.vector.Vector3f;
+
+public class DStaticPropV7VIN extends DStaticPropV6 implements DStaticPropVinScaling {
+
+    public Vector3f scaling = new Vector3f(1, 1, 1);
+
+    @Override
+    public Vector3f getScaling() {
+        return scaling;
+    }
+
+    @Override
+    public void setScaling(Vector3f scaling) {
+        this.scaling = scaling;
+    }
+}

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropV7VIN.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropV7VIN.java
@@ -2,6 +2,8 @@ package info.ata4.bsplib.struct;
 
 import info.ata4.bsplib.vector.Vector3f;
 
+import java.util.Objects;
+
 public class DStaticPropV7VIN extends DStaticPropV6 implements DStaticPropVinScaling {
 
     public Vector3f scaling = new Vector3f(1, 1, 1);
@@ -13,6 +15,6 @@ public class DStaticPropV7VIN extends DStaticPropV6 implements DStaticPropVinSca
 
     @Override
     public void setScaling(Vector3f scaling) {
-        this.scaling = scaling;
+        this.scaling = Objects.requireNonNull(scaling);
     }
 }

--- a/src/main/java/info/ata4/bsplib/struct/DStaticPropVinScaling.java
+++ b/src/main/java/info/ata4/bsplib/struct/DStaticPropVinScaling.java
@@ -1,0 +1,9 @@
+package info.ata4.bsplib.struct;
+
+import info.ata4.bsplib.vector.Vector3f;
+
+public interface DStaticPropVinScaling {
+
+    Vector3f getScaling();
+    void setScaling(Vector3f scale);
+}

--- a/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/entity/EntitySource.java
@@ -738,8 +738,8 @@ public class EntitySource extends ModuleDecompile {
                 writer.put("ignorenormals", pst6.hasIgnoreNormals());
             }
 
-            if (pst instanceof DStaticPropV6VIN) {
-                writer.put("scale", ((DStaticPropV6VIN) pst).scaling);
+            if (pst instanceof DStaticPropVinScaling) {
+                writer.put("scale", ((DStaticPropVinScaling) pst).getScaling());
             }
 
             // write that later; both v7 and v8 have it, but v8 extends v5


### PR DESCRIPTION
Adds support for Vindictus sprp version 7 (DStaticPropV7VIN), which is identical to the **standard** version 6 (DStaticPropV6), but like it’s own version 6 (DStaticPropV6VIN), has an additional array of scaling vectors before the static prop array.

Fixes: #91