### PR TITLE
Fix duplicated map comment

### DIFF
--- a/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
+++ b/src/main/java/info/ata4/bspsrc/modules/BspDecompiler.java
@@ -84,7 +84,7 @@ public class BspDecompiler extends ModuleDecompile {
         }
 
         // set comment
-        vmfmeta.setComment("Decompiled by BSPSource v" + BspSource.VERSION + " from " + bspFile.getName());
+        vmfmeta.appendComment("Decompiled by BSPSource v" + BspSource.VERSION + " from " + bspFile.getName());
 
         // start worldspawn
         vmfmeta.writeWorldHeader();

--- a/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
+++ b/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
@@ -58,14 +58,17 @@ public class VmfMeta extends ModuleDecompile {
     private List<Camera> cameras = new ArrayList<>();
 
     private Entity worldspawn;
-    private String comment;
 
     public VmfMeta(BspFileReader reader, VmfWriter writer) {
         super(reader, writer);
 
         if (bsp.entities.isEmpty())
         {
-            L.warning("Couldn't get Worldspawn-entity, because entity list is empty (Probably because map uses external lump files). The map may be missing some information like skybox or detail sprites...");
+            L.warning("Couldn't get Worldspawn-entity, because entity list is empty " +
+                    "(Probably because map uses external lump files). The map may be missing " +
+                    "some information like skybox or detail sprites...");
+
+            worldspawn = new Entity("worldspawn");
         } else {
             worldspawn = bsp.entities.get(0);
 
@@ -168,12 +171,12 @@ public class VmfMeta extends ModuleDecompile {
         return dispinfoUIDs.put(idispinfo, id);
     }
 
-    public void setComment(String comment) {
-        this.comment = comment;
+    public void appendComment(String comment) {
+        worldspawn.setValue("comment", getComment().map(s -> s + " | ").orElse("") + comment);
     }
 
-    public String getComment() {
-        return comment;
+    public Optional<String> getComment() {
+        return Optional.ofNullable(worldspawn.getValue("comment"));
     }
 
     /**
@@ -182,14 +185,7 @@ public class VmfMeta extends ModuleDecompile {
     public void writeWorldHeader() {
         writer.start("world");
         writer.put("id", getUID());
-        if (worldspawn != null)
-            writer.put(worldspawn);
-
-        // write comment
-        if (comment != null) {
-            writer.put("comment", comment);
-        }
-
+        writer.put(worldspawn);
         writer.put("classname", "worldspawn");
     }
 

--- a/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
+++ b/src/main/java/info/ata4/bspsrc/modules/VmfMeta.java
@@ -62,20 +62,20 @@ public class VmfMeta extends ModuleDecompile {
     public VmfMeta(BspFileReader reader, VmfWriter writer) {
         super(reader, writer);
 
-        if (bsp.entities.isEmpty())
-        {
-            L.warning("Couldn't get Worldspawn-entity, because entity list is empty " +
-                    "(Probably because map uses external lump files). The map may be missing " +
-                    "some information like skybox or detail sprites...");
+        worldspawn = bsp.entities.stream()
+                .filter(entity -> entity.getClassName().equalsIgnoreCase("worldspawn"))
+                .findAny()
+                .orElseGet(() -> {
+                    L.warning("Couldn't find worldspawn entity. This may be due to the map having stripped " +
+                            "entities. Some information like skybox and detail sprites will be missing, " +
+                            "because these are saved in the worldspawn entity");
 
-            worldspawn = new Entity("worldspawn");
-        } else {
-            worldspawn = bsp.entities.get(0);
+                    return new Entity("worldspawn");
+                });
 
-            // check for existing map comment
-            if (worldspawn.getValue("comment") != null) {
-                L.log(Level.INFO, "Map comment: {0}", worldspawn.getValue("comment"));
-            }
+        // print existing map comment
+        if (worldspawn.getValue("comment") != null) {
+            L.log(Level.INFO, "Map comment: {0}", worldspawn.getValue("comment"));
         }
     }
 


### PR DESCRIPTION
The decompiler automatically adds `Decompiled by BSPSource..` as a map comment to the vmf. If, however, the map already has a comment, the decompiler incorrectly writes two comments into the final vmf.
This pull request is a simple fix, so that the `Decompiled by BSPSource..` is simply appended to the comment instead of creating a second one.