### PR TITLE
VectorUtil refactor

### DIFF
--- a/src/main/java/info/ata4/bsplib/vector/Vector2f.java
+++ b/src/main/java/info/ata4/bsplib/vector/Vector2f.java
@@ -107,6 +107,16 @@ public class Vector2f extends VectorXf {
 	}
 
 	/**
+	 * Z-Component of the cross product with the 2 vectors lying on a 3d xy-plane
+	 *
+	 * @param that the vector to take a cross product
+	 * @return the z component of the cross-product vector
+	 */
+	public float cross(Vector2f that) {
+		return this.x * that.y - that.x * this.y;
+	}
+
+	/**
 	 * Vector normalisation: ^this
 	 *
 	 * @return the normalised vector

--- a/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/AreaportalMapper.java
@@ -4,7 +4,6 @@ import info.ata4.bsplib.entity.KeyValue;
 import info.ata4.bsplib.struct.BspData;
 import info.ata4.bsplib.struct.DAreaportal;
 import info.ata4.bsplib.struct.DBrush;
-import info.ata4.bsplib.util.VectorUtil;
 import info.ata4.bspsrc.BspSourceConfig;
 import info.ata4.bspsrc.VmfWriter;
 import info.ata4.bspsrc.modules.VmfMeta;

--- a/src/main/java/info/ata4/bspsrc/util/ConvexPolygon.java
+++ b/src/main/java/info/ata4/bspsrc/util/ConvexPolygon.java
@@ -18,7 +18,7 @@ public class ConvexPolygon extends AbstractList<Vector2f> {
 
     public ConvexPolygon(Vector2f... vertices) {
         if (vertices.length < 3) {
-            throw new IllegalArgumentException("Vertices array must have atleast 3 vertices");
+            throw new IllegalArgumentException("Vertices array must have at least 3 vertices");
         }
 
         this.vertices = vertices.clone();

--- a/src/main/java/info/ata4/bspsrc/util/ConvexPolygon.java
+++ b/src/main/java/info/ata4/bspsrc/util/ConvexPolygon.java
@@ -86,19 +86,20 @@ public class ConvexPolygon extends AbstractList<Vector2f> {
 
     /**
      * Test if the specified position is inside this convex polygon.
+     * <p>A position is also considered to be inside this polygon, if it's
+     * directly on one of its edges
      *
      * @param position The specific position
      * @return true if the specified position is inside the convex polygon
-     *
-     * @see <a href="https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html">
-     *     https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html</a>
      */
     public boolean containsPosition(Vector2f position) {
         return Arrays.stream(edges)
-                .filter(edge -> (edge.start.y > position.y) != (edge.end.y > position.y)
-                        && (position.x < (edge.end.x - edge.start.x) * (position.y - edge.start.y)
-                        / (edge.end.y - edge.start.y) + edge.start.x))
-                .count() % 2 == 1;
+                .map(edge -> edge.getDirectionVector().cross(position.sub(edge.start)))
+                .filter(cross -> cross != 0)
+                .map(cross -> cross > 0)
+                .distinct()
+                .limit(2)
+                .count() <= 1;
     }
 
     /**

--- a/src/main/java/info/ata4/bspsrc/util/ConvexPolygon.java
+++ b/src/main/java/info/ata4/bspsrc/util/ConvexPolygon.java
@@ -1,0 +1,205 @@
+package info.ata4.bspsrc.util;
+
+import info.ata4.bsplib.vector.Vector2f;
+import info.ata4.util.JavaUtil;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ConvexPolygon extends AbstractList<Vector2f> {
+
+    public final Vector2f[] vertices;
+    public final Line[] edges;
+
+    public ConvexPolygon(List<Vector2f> list) {
+        this(list.toArray(new Vector2f[0]));
+    }
+
+    public ConvexPolygon(Vector2f... vertices) {
+        if (vertices.length < 3) {
+            throw new IllegalArgumentException("Vertices array must have atleast 3 vertices");
+        }
+
+        this.vertices = vertices.clone();
+        this.edges = IntStream.range(0, vertices.length)
+                .mapToObj(i -> new Line(vertices[i], vertices[(i + 1) % vertices.length]))
+                .toArray(Line[]::new);
+
+        assert verifyConvex() : "Provided vertices don't create convex polygon: " + Arrays.toString(vertices);
+    }
+
+    private boolean verifyConvex() {
+        return Arrays.stream(edges)
+                .flatMap(edge -> Arrays.stream(vertices)
+                        .map(vertex -> edge.getDirectionVector().cross(vertex.sub(edge.start)))
+                        .filter(cross -> cross != 0)
+                        .map(cross -> cross > 0))
+                .distinct()
+                .limit(2)
+                .count() <= 1;
+    }
+
+    /**
+     * Calculates the intersecting convex polygon between this convex polygon and the specified one.
+     *
+     * @param polygon The other convex polygon
+     * @return an {@code Optional<ConvexPolygon>} representing the intersection of the two
+     *         polygons or an empty Optional if there is no intersection
+     */
+    public Optional<ConvexPolygon> getIntersectionPolygon(ConvexPolygon polygon) {
+        Set<Vector2f> intersectingVertices = new HashSet<>();
+
+        // Find all corners of w1 that are inside of w2
+        intersectingVertices.addAll(this.stream()
+                .filter(polygon::containsPosition)
+                .collect(Collectors.toList()));
+
+        // Find all corners of w2 that are inside of w1
+        intersectingVertices.addAll(polygon.stream()
+                .filter(this::containsPosition)
+                .collect(Collectors.toList()));
+
+        // Find all intersections of the 2 polygons
+        intersectingVertices.addAll(this.getIntersectionVertices(polygon));
+
+        if (intersectingVertices.size() < 3) {
+            return Optional.empty();
+        } else {
+            // Order all vertices creating a valid convex polygon
+            return Optional.of(fromUnorderedVertices(intersectingVertices));
+        }
+    }
+
+    /**
+     * Calculates the intersection points of the two convex polygons
+     *
+     * @param polygon The other convex polygon
+     * @return A {@code Set<Vector2f>} of intersection points
+     */
+    public Set<Vector2f> getIntersectionVertices(ConvexPolygon polygon) {
+        return Arrays.stream(edges)
+                .flatMap(edge -> Arrays.stream(polygon.edges)
+                        .flatMap(otherEdge -> JavaUtil.streamOpt(edge.getIntersectionPoint(otherEdge))))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Test if the specified position is inside this convex polygon.
+     *
+     * @param position The specific position
+     * @return true if the specified position is inside the convex polygon
+     *
+     * @see <a href="https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html">
+     *     https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html</a>
+     */
+    public boolean containsPosition(Vector2f position) {
+        return Arrays.stream(edges)
+                .filter(edge -> (edge.start.y > position.y) != (edge.end.y > position.y)
+                        && (position.x < (edge.end.x - edge.start.x) * (position.y - edge.start.y)
+                        / (edge.end.y - edge.start.y) + edge.start.x))
+                .count() % 2 == 1;
+    }
+
+    /**
+     * Calculates the area of this convex polygon
+     *
+     * @return the area of this convex polygon
+     */
+    public float getArea() {
+        return (float) Math.abs(Arrays.stream(edges)
+                .mapToDouble(edge -> edge.start.cross(edge.end))
+                .sum() / 2);
+    }
+
+    /**
+     * Get the vertex at the specified index
+     *
+     * @param index The index of the vertex
+     * @return the vertex at the specified index
+     */
+    @Override
+    public Vector2f get(int index) {
+        return vertices[index];
+    }
+
+    /**
+     * Returns the amount of vertices this convex polygon has
+     *
+     * @return the amount of vertices
+     */
+    @Override
+    public int size() {
+        return vertices.length;
+    }
+
+    /**
+     * Creates a convex polygon by sorting the provided vertices by their rotation around
+     * the midpoint of all vertices
+     *
+     * @param vertices A collection of unordered vertices
+     * @return A {@link ConvexPolygon} with the provided vertices
+     */
+    public static ConvexPolygon fromUnorderedVertices(Collection<Vector2f> vertices) {
+        Vector2f midPoint = vertices.stream()
+                .reduce((vertex1, vertex2) -> vertex1.add(vertex2).scalar(0.5f))
+                .orElse(Vector2f.NULL);
+
+        return new ConvexPolygon(vertices.stream()
+                .sorted(Comparator.comparingDouble(vertex -> Math.atan2(vertex.x - midPoint.x, vertex.y - midPoint.y)))
+                .toArray(Vector2f[]::new));
+    }
+
+    /**
+     * An Edge represented by a starting point and end point
+     */
+    private static class Line {
+
+        public final Vector2f start;
+        public final Vector2f end;
+
+        public Line(Vector2f start, Vector2f end) {
+            this.start = Objects.requireNonNull(start);
+            this.end = Objects.requireNonNull(end);
+        }
+
+        /**
+         * @return the direction vector for this line
+         */
+        public Vector2f getDirectionVector() {
+            return end.sub(start);
+        }
+
+        /**
+         * Calculates the intersection point between the two lines.
+         *
+         * @param otherLine The other line for with a intersection should be calculated
+         * @return an {@code Optional<Vector2f>} of the intersection point or an empty
+         *         optional, if there is none
+         *
+         * @see <a href="https://stackoverflow.com/a/565282">https://stackoverflow.com/a/565282</a>
+         */
+        public Optional<Vector2f> getIntersectionPoint(Line otherLine) {
+            Vector2f cmP = otherLine.start.sub(this.start);
+            Vector2f r = this.getDirectionVector();
+            Vector2f s = otherLine.getDirectionVector();
+
+            float cmPxr = cmP.cross(r);
+            float cmPxs = cmP.cross(s);
+            float rxs = r.cross(s);
+
+            if (rxs == 0f) {
+                return Optional.empty(); // Lines are parallel.
+            }
+
+            float t = cmPxs / rxs;
+            float u = cmPxr / rxs;
+
+            if ((t >= 0f) && (t <= 1f) && (u >= 0f) && (u <= 1f)) {
+                return Optional.of(start.add(r.scalar(t)));
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
+++ b/src/main/java/info/ata4/bspsrc/util/OccluderMapper.java
@@ -1,7 +1,6 @@
 package info.ata4.bspsrc.util;
 
 import info.ata4.bsplib.struct.*;
-import info.ata4.bsplib.util.VectorUtil;
 import info.ata4.bspsrc.BspSourceConfig;
 import info.ata4.log.LogUtils;
 

--- a/src/main/java/info/ata4/bspsrc/util/VectorUtil.java
+++ b/src/main/java/info/ata4/bspsrc/util/VectorUtil.java
@@ -4,12 +4,11 @@ import info.ata4.bsplib.struct.BspData;
 import info.ata4.bsplib.struct.DBrush;
 import info.ata4.bsplib.struct.DBrushSide;
 import info.ata4.bsplib.struct.DOccluderPolyData;
-import info.ata4.bsplib.vector.Vector2f;
 import info.ata4.bsplib.vector.Vector3f;
 
-import java.util.*;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class VectorUtil {
 
@@ -60,101 +59,25 @@ public class VectorUtil {
 		Vector3f axis2 = axis1.cross(planeNormal).normalize(); //Vector orthogonal to axis1 and planeNormal
 
 		//Map 3d coordinates of windings to 2d (2d coordinates on the plane they lie on)
-		List<Vector2f> w1Polygon = w1.stream()
+		ConvexPolygon w1Polygon = w1.stream()
 				.map(vertex -> vertex.getAsPointOnPlane(origin, axis1, axis2))
-				.collect(Collectors.toList());
+				.collect(Collectors.collectingAndThen(Collectors.toList(), ConvexPolygon::new));
 
-		List<Vector2f> w2Polygon = w2.stream()
+		ConvexPolygon w2Polygon = w2.stream()
 				.map(vertex -> vertex.getAsPointOnPlane(origin, axis1, axis2))
-				.collect(Collectors.toList());
+				.collect(Collectors.collectingAndThen(Collectors.toList(), ConvexPolygon::new));
 
-		Set<Vector2f> intersectingVertices = new HashSet<>();
+		Optional<ConvexPolygon> intersectionPolygon = w1Polygon.getIntersectionPolygon(w2Polygon);
+		if (!intersectionPolygon.isPresent()) {
+			return 0;
+		} else {
+			float intersectionArea = intersectionPolygon.get().getArea();
+			// error margin
+			if (intersectionArea < 1) {
+				intersectionArea = 0;
+			}
 
-		// Find all corners of w1 that are inside of w2
-		intersectingVertices.addAll(w1Polygon.stream()
-				.filter(vertex -> VectorUtil.isInsideConvexPolygon(vertex, w2Polygon))
-				.collect(Collectors.toList()));
-
-		// Find all corners of w2 that are inside of w1
-		intersectingVertices.addAll(w2Polygon.stream()
-				.filter(vertex -> VectorUtil.isInsideConvexPolygon(vertex, w1Polygon))
-				.collect(Collectors.toList()));
-
-		// Find all intersections of the 2 polygons
-		intersectingVertices.addAll(VectorUtil.getPolygonIntersections(w1Polygon, w2Polygon));
-
-		// Order all vertices creating a valid convex polygon
-		List<Vector2f> intersectionPolygon = VectorUtil.orderVertices(intersectingVertices);
-
-		double intersectionArea = VectorUtil.polygonArea(intersectionPolygon);
-		// error margin
-		if (intersectionArea < 1)
-			intersectionArea = 0;
-
-		double w1Area = VectorUtil.polygonArea(w1Polygon);
-
-		return Math.min(intersectionArea / w1Area, 1);
-	}
-
-	//https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
-	public static boolean isInsideConvexPolygon(Vector2f p, List<Vector2f> polygon) {
-		return IntStream.range(0, polygon.size())
-				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
-				.filter(edge -> (edge[0].y > p.y) != (edge[1].y > p.y)
-						&& (p.x < (edge[1].x - edge[0].x) * (p.y - edge[0].y) / (edge[1].y - edge[0].y) + edge[0].x))
-				.limit(2)
-				.count() % 2 == 1;
-	}
-
-
-	public static Set<Vector2f> getPolygonIntersections(List<Vector2f> polygon1, List<Vector2f> polygon2) {
-		return IntStream.range(0, polygon1.size())
-				.mapToObj(i -> new Vector2f[]{polygon1.get(i), polygon1.get((i + 1) % polygon1.size())})
-				.flatMap(edge -> IntStream.range(0, polygon2.size())
-						.mapToObj(i -> new Vector2f[]{polygon2.get(i), polygon2.get((i + 1) % polygon2.size())})
-						.map(edge2 -> lineIntersection(edge[0], edge[1], edge2[0], edge2[1])))
-				.filter(Optional::isPresent)
-				.map(Optional::get)
-				.collect(Collectors.toSet());
-	}
-
-	//https://stackoverflow.com/a/565282
-	public static Optional<Vector2f> lineIntersection(Vector2f origin1, Vector2f end1, Vector2f origin2, Vector2f end2) {
-		Vector2f cmP = origin2.sub(origin1);
-		Vector2f r = end1.sub(origin1);
-		Vector2f s = end2.sub(origin2);
-
-		float CmPxr = cmP.x * r.y - cmP.y * r.x;
-		float CmPxs = cmP.x * s.y - cmP.y * s.x;
-		float rxs = r.x * s.y - r.y * s.x;
-
-		if (rxs == 0f)
-			return Optional.empty(); // Lines are parallel.
-
-		float rxsr = 1f / rxs;
-		float t = CmPxs * rxsr;
-		float u = CmPxr * rxsr;
-
-		if ((t >= 0f) && (t <= 1f) && (u >= 0f) && (u <= 1f))
-			return Optional.of(origin1.add(end1.sub(origin1).scalar(t)));
-		else
-			return Optional.empty();
-	}
-
-	public static double polygonArea(List<Vector2f> polygon) {
-		return Math.abs(IntStream.range(0, polygon.size())
-				.mapToObj(i -> new Vector2f[]{polygon.get(i), polygon.get((i + 1) % polygon.size())})
-				.mapToDouble(edge -> (edge[0].x + edge[1].x) * (edge[0].y - edge[1].y))
-				.sum() / 2);
-	}
-
-	public static List<Vector2f> orderVertices(Collection<Vector2f> vertices) {
-		Vector2f midPoint = vertices.stream()
-				.reduce((vertex1, vertex2) -> vertex1.add(vertex2).scalar(0.5f))
-				.orElse(new Vector2f(0, 0));
-
-		return vertices.stream()
-				.sorted(Comparator.comparingDouble(vertex -> Math.atan2(vertex.x - midPoint.x, vertex.y - midPoint.y)))
-				.collect(Collectors.toList());
+			return Math.min(intersectionArea / w1Polygon.getArea(), 1);
+		}
 	}
 }

--- a/src/main/java/info/ata4/bspsrc/util/VectorUtil.java
+++ b/src/main/java/info/ata4/bspsrc/util/VectorUtil.java
@@ -39,11 +39,11 @@ public class VectorUtil {
 	}
 
 	/**
-	 * Returns the touching area of two Winding's in percent to w1 (0-1)
-	 * <p><b>This assumes that the 2 windings already lie in the same plane!!!</b></p>
+	 * Returns the intersecting area of two Windings in percentage to w1 total area (0-1)
+	 * <p><b>This assumes that the 2 windings already lie in the same plane!!!
 	 *
-	 * @param w1 the areaportal this brush is compared to
-	 * @param w2 a winding representing the brush side
+	 * @param w1 the first winding
+	 * @param w2 the second winding
 	 * @return A probability in form of a double ranging from 0 to 1
 	 */
 	private static double internalMatchingAreaPercentage(Winding w1, Winding w2) {

--- a/src/main/java/info/ata4/bspsrc/util/VectorUtil.java
+++ b/src/main/java/info/ata4/bspsrc/util/VectorUtil.java
@@ -1,4 +1,4 @@
-package info.ata4.bsplib.util;
+package info.ata4.bspsrc.util;
 
 import info.ata4.bsplib.struct.BspData;
 import info.ata4.bsplib.struct.DBrush;
@@ -6,9 +6,6 @@ import info.ata4.bsplib.struct.DBrushSide;
 import info.ata4.bsplib.struct.DOccluderPolyData;
 import info.ata4.bsplib.vector.Vector2f;
 import info.ata4.bsplib.vector.Vector3f;
-import info.ata4.bspsrc.util.AreaportalMapper;
-import info.ata4.bspsrc.util.Winding;
-import info.ata4.bspsrc.util.WindingFactory;
 
 import java.util.*;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## Introduction
With #57 I introduced the `VectorUtil` class used for the Areaportal/Occluder mapper. The purpose of its methods is to compare `Windings` by their surface area and get the overlap as a percentage. Internally this is done by first testing if both windings share a common plane and then converting them to 2 dimensional convex polygons to make comparison easy.

### Changes
Previously, all relevant calculations were all done in the `VectorUtil` class. To make the class less bloated with methods, this pr transfers some of that code into a new class called `ConvexPolygon`. As the name already suggest, this is a class which represents a convex polygon defined by a list of vertex positions.

Additionally, there are also some improvements to the javadoc and the algorithm for testing if a position is inside a convex polygon has been change to a different one.

Practically, this pr shouldn't change anything visible to the user but rather just improve code readability and reusability.