### PR TITLE
Fix Black Mesa 4-way blend decompiling

### DIFF
--- a/src/main/java/info/ata4/bsplib/BspFileReader.java
+++ b/src/main/java/info/ata4/bsplib/BspFileReader.java
@@ -530,7 +530,15 @@ public class BspFileReader {
             return;
         }
 
-        bspData.dispmultiblend = loadLump(LumpType.LUMP_DISP_MULTIBLEND, DDispMultiBlend.class);
+        // black mesa uses the LUMP_OVERLAY_SYSTEM_LEVELS lump to store multiblend information.
+        // the original purpose of that lump is no longer used
+        LumpType lumpType;
+        if (appID == BLACK_MESA)
+            lumpType = LumpType.LUMP_OVERLAY_SYSTEM_LEVELS;
+        else
+            lumpType = LumpType.LUMP_DISP_MULTIBLEND;
+
+        bspData.dispmultiblend = loadLump(lumpType, DDispMultiBlend.class);
     }
 
     public void loadTexInfo() {
@@ -717,7 +725,11 @@ public class BspFileReader {
 
         // read CPU/GPU levels
         if (bspData.overlaySysLevels == null) {
-            bspData.overlaySysLevels = loadLump(LumpType.LUMP_OVERLAY_SYSTEM_LEVELS, DOverlaySystemLevel.class);
+            // black mesa uses this lump for displacement multiblend
+            if (appID == BLACK_MESA)
+                bspData.overlaySysLevels = Collections.emptyList();
+            else
+                bspData.overlaySysLevels = loadLump(LumpType.LUMP_OVERLAY_SYSTEM_LEVELS, DOverlaySystemLevel.class);
         }
     }
 


### PR DESCRIPTION
## Introduction
When creating 4-way blend displacements, the multi blend information is stored in the `LUMP_DISP_MULTIBLEND` lump, which is located at the index 63.
Bspsrc already correctly reads this lumps and converts the information into the resulting vmf.
Black Mesa however, doesn't store the `LUMP_DISP_MULTIBLEND`  lump at index 63, but rather at 61 which caused all multi blend information to be lost. The original lump located at index 61 doesn't seem to be used by the game.

## Changes
This PR simply introduces 2 checks in the bsp file reading part to circumvent this issue.
1. `loadDispMultiBlend()` now uses the lump at index 61 (`LUMP_OVERLAY_SYSTEM_LEVELS`) if the game is Black Mesa.
2. `loadOverlays()` now simply saves an empty list to `bspData.overlaySysLevels` if the game is Black Mesa, instead of reading the `LUMP_OVERLAY_SYSTEM_LEVELS` lump.

## Implications/Considerations
While the fix for this problem is pretty simple, the fact that the lump structure can differ from game to game, has certain implications to the code base. Currently one global `LumpType` enum exists, which maps lump indices to lump names in a `1 to 1` mapping. But because different games can have different meanings to lump indices, there need to be game specific lump types, resulting in a `1 to n` mapping.
In other words the `LumpType` class would need to be changed to take the game into consideration.

However, I didn't do this work for now because I'm not completely sure about all implications this has.
So while this PR does fix the issue, ideally this should be revisited at some point.

Fixes #114 
