### PR TITLE
Refactor tooltexture fixing system

### DIFF
--- a/src/main/java/info/ata4/bsplib/app/SourceAppID.java
+++ b/src/main/java/info/ata4/bsplib/app/SourceAppID.java
@@ -22,6 +22,7 @@ public class SourceAppID {
     public static final int UNKNOWN = 0;
     public static final int VINDICTUS = -100;
     public static final int HALF_LIFE_2 = 220;
+    public static final int COUNTER_STRIKE_SOURCE = 240;
     public static final int LEFT_4_DEAD = 500;
     public static final int LEFT_4_DEAD_2 = 550;
     public static final int DARK_MESSIAH = 2100;

--- a/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/TextureSource.java
@@ -12,6 +12,7 @@ package info.ata4.bspsrc.modules.texture;
 
 import info.ata4.bsplib.BspFileReader;
 import info.ata4.bspsrc.modules.ModuleRead;
+import info.ata4.bspsrc.modules.texture.tooltextures.ToolTextureSet;
 import info.ata4.log.LogUtils;
 import org.apache.commons.io.FilenameUtils;
 
@@ -55,6 +56,8 @@ public class TextureSource extends ModuleRead {
     // settings
     private boolean fixTextureNames;
     private boolean fixToolTextures;
+    private ToolTextureMatcher toolTextureMatcher =
+            new ToolTextureMatcher(ToolTextureSet.forGame(bspFile.getSourceApp().getAppID()));
 
     public TextureSource(BspFileReader reader) {
         super(reader);
@@ -146,7 +149,7 @@ public class TextureSource extends ModuleRead {
     }
 
     public TextureBuilder getTextureBuilder() {
-        return new TextureBuilder(this, bsp, bspFile.getSourceApp().getAppID());
+        return new TextureBuilder(this, bsp, toolTextureMatcher);
     }
 
     public void addBrushSideID(int itexname, int side) {

--- a/src/main/java/info/ata4/bspsrc/modules/texture/ToolTexture.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/ToolTexture.java
@@ -46,4 +46,23 @@ public final class ToolTexture {
     //CSGO Only
     public static final String CSGO_GRENADECLIP = "tools/toolsgrenadeclip";
     public static final String CSGO_DRONECLIP = "tools/toolsdroneclip";
+
+    public static final String CSGO_CLIP_CONCRETE = "tools/toolsclip_concrete";
+    public static final String CSGO_CLIP_DIRT = "tools/toolsclip_dirt";
+    public static final String CSGO_CLIP_GLASS = "tools/toolsclip_glass";
+    public static final String CSGO_CLIP_GRASS = "tools/toolsclip_grass";
+    public static final String CSGO_CLIP_GRAVEL = "tools/toolsclip_gravel";
+    public static final String CSGO_CLIP_METAL = "tools/toolsclip_metal";
+    public static final String CSGO_CLIP_METAL_SAND_BARREL = "tools/toolsclip_metal_sand_barrel";
+    public static final String CSGO_CLIP_METALGRATE = "tools/toolsclip_metalgrate";
+    public static final String CSGO_CLIP_METALVEHICEL = "tools/toolsclip_metalvehicle";
+    public static final String CSGO_CLIP_PLASTIC = "tools/toolsclip_plastic";
+    public static final String CSGO_CLIP_RUBBER = "tools/toolsclip_rubber";
+    public static final String CSGO_CLIP_RUBBERTIRE = "tools/toolsclip_rubbertire";
+    public static final String CSGO_CLIP_SAND = "tools/toolsclip_sand";
+    public static final String CSGO_CLIP_SNOW = "tools/toolsclip_snow";
+    public static final String CSGO_CLIP_TILE = "tools/toolsclip_tile";
+    public static final String CSGO_CLIP_WOOD = "tools/toolsclip_wood";
+    public static final String CSGO_CLIP_WOOD_BASKET = "tools/toolsclip_wood_basket";
+    public static final String CSGO_CLIP_WOOD_CRATE = "tools/toolsclip_wood_crate";
 }

--- a/src/main/java/info/ata4/bspsrc/modules/texture/ToolTexture.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/ToolTexture.java
@@ -27,6 +27,7 @@ public final class ToolTexture {
     public static final String INVIS = "tools/toolsinvisible";
     public static final String ORANGE = "dev/dev_measuregeneric01";
     public static final String SKIP = "tools/toolsskip";
+    public static final String HINT = "tools/toolshint";
     public static final String CLIP = "tools/toolsclip";
     public static final String PLAYERCLIP = "tools/toolsplayerclip";
     public static final String NPCCLIP = "tools/toolsnpcclip";
@@ -38,6 +39,9 @@ public final class ToolTexture {
     public static final String DOTTED = "tools/toolsdotted";
     public static final String OCCLUDER = "tools/toolsoccluder";
     public static final String TRIGGER = "tools/toolstrigger";
+    public static final String FOG = "tools/toolsfog";
+    public static final String SKYBOX = "tools/toolsskybox";
+    public static final String SKYBOX2D = "tools/toolsskybox2d";
 
     //CSGO Only
     public static final String CSGO_GRENADECLIP = "tools/toolsgrenadeclip";

--- a/src/main/java/info/ata4/bspsrc/modules/texture/ToolTextureMatcher.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/ToolTextureMatcher.java
@@ -1,0 +1,85 @@
+package info.ata4.bspsrc.modules.texture;
+
+import info.ata4.bsplib.struct.BrushFlag;
+import info.ata4.bsplib.struct.SurfaceFlag;
+import info.ata4.bspsrc.modules.texture.tooltextures.ToolTextureDefinition;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
+
+/**
+ * Class for reversing texture names to their original tooltexture names/surface flags/brush flags.
+ *
+ * <p> In the vbsp optimizing process, every brushside that points to a texinfo, that is <b>not</b> referenced by any
+ * face, will be changed to point to an already referenced texinfo. This is probably done to save space in the
+ * texinfo lump.
+ *
+ * <p> This has the effect that all brushsides, that don't create a visible face, have their textures messed up.
+ * Especially tooltextures are affected by this, as they are invisible and consequently don't generate any faces.
+ *
+ * <p> This class uses the surface property and surface/brush flags to reverse the original texture names. This is
+ * achieved, by having a set of all possible textures mapped to what brush/surface flags they're required/forbidden to
+ * have + which surface flag the require.
+ *
+ * <p> While surface/brush flags can be directly retrieved, the surface property is not directly saved in the bsp, but
+ * rather has to be looked up through its texture/material. Remembering that the texture name changes makes this seem
+ * useless. However, the algorithm for optimizing texinfos can only choose different textures with the <b>same surface
+ * property</b>, enabling us to directly lookup the surface property by the texture name, even if the texture name
+ * isn't the one originally used on the brush side.
+ *
+ * @see <a href="https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/utils/vbsp/writebsp.cpp#L768">
+ *     https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/utils/vbsp/writebsp.cpp#L768</a>
+ * @see <a href="https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/utils/vbsp/writebsp.cpp#L676">
+ *     https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/utils/vbsp/writebsp.cpp#L676</a>
+ */
+public class ToolTextureMatcher {
+
+    private final Map<String, ToolTextureDefinition> toolTextureDefinitions;
+
+    public ToolTextureMatcher(Map<String, ToolTextureDefinition> toolTextureDefinitions) {
+        this.toolTextureDefinitions = Collections.unmodifiableMap(new HashMap<>(toolTextureDefinitions));
+    }
+
+    /**
+     * Tries to make the best guess, which texture name the specified surface property, brush/surface flags represent.
+     *
+     * @param originalTextureName the original texture name
+     * @param surfFlags a set of {@link SurfaceFlag}s
+     * @param brushFlags a set of {@link BrushFlag}s
+     *
+     * @return an empty optional if no texture name could be found or the best guess
+     */
+    public Optional<String> fixToolTexture(String originalTextureName, Set<SurfaceFlag> surfFlags,
+                                           Set<BrushFlag> brushFlags) {
+
+        // Optional of optional of string -> first optional empty if we don't have a definition of originalTextureName
+        // second optional empty if we do have a definition but it doesn't have a surfaceproperty specified
+        Optional<Optional<String>> optOriginalSurfaceProperty = Optional.ofNullable(toolTextureDefinitions.get(originalTextureName))
+                .map(ToolTextureDefinition::getSurfaceProperty);
+
+        return toolTextureDefinitions.entrySet().stream()
+                .filter(ttEntry -> optOriginalSurfaceProperty
+                        .map(surfaceProperty -> StringUtils.equalsIgnoreCase( // are surface properties case sensitive?
+                                surfaceProperty.orElse(null),
+                                ttEntry.getValue()
+                                        .getSurfaceProperty()
+                                        .orElse(null)
+                        ))
+                        .orElse(true))
+                .filter(ttEntry -> ttEntry.getValue().getBrushFlagsRequirements()
+                        .entrySet()
+                        .stream()
+                        .allMatch(entry -> brushFlags.contains(entry.getKey()) == entry.getValue()))
+                .filter(ttEntry -> ttEntry.getValue().getSurfaceFlagsRequirements()
+                        .entrySet()
+                        .stream()
+                        .allMatch(entry -> surfFlags.contains(entry.getKey()) == entry.getValue()))
+                .max(Comparator.comparingInt(ttEntry -> {
+                    ToolTextureDefinition definition = ttEntry.getValue();
+                    int brushFlagRequirements = definition.getBrushFlagsRequirements().size();
+                    int surfaceFlagRequirements = definition.getSurfaceFlagsRequirements().size();
+                    return brushFlagRequirements + surfaceFlagRequirements;
+                }))
+                .map(Map.Entry::getKey);
+    }
+}

--- a/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureDefinition.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureDefinition.java
@@ -1,0 +1,125 @@
+package info.ata4.bspsrc.modules.texture.tooltextures;
+
+import info.ata4.bsplib.struct.BrushFlag;
+import info.ata4.bsplib.struct.SurfaceFlag;
+
+import java.util.*;
+
+public interface ToolTextureDefinition {
+
+    /**
+     * Note: While the engine may use some form of default surface property for materials which
+     * have none specified, the vbsp optimizing process does seem to differentiate between these two.
+     * <p>This is the reason we return an Optional here.
+     *
+     * @return an optional containing the surface property the texture has or an empty optional
+     */
+    Optional<String> getSurfaceProperty();
+
+    /**
+     * @return a set of brush flags that are either required(true) or forbidden(false) to have
+     */
+    Map<BrushFlag, Boolean> getBrushFlagsRequirements();
+
+    /**
+     * @return a set of surface flags that are either required(true) or forbidden(false) to have
+     */
+    Map<SurfaceFlag, Boolean> getSurfaceFlagsRequirements();
+
+    /**
+     * A Builder class for {@link ToolTextureDefinition}s
+     */
+    public class Builder {
+
+        private String surfaceProperty;
+        private final Map<BrushFlag, Boolean> brushFlagsRequirements = new HashMap<>();
+        private final Map<SurfaceFlag, Boolean> surfaceFlagsRequirements = new HashMap<>();
+
+        public Builder() {
+            this((String) null);
+        }
+
+        public Builder(String surfaceProperty) {
+            this.surfaceProperty = surfaceProperty;
+        }
+
+        public Builder(ToolTextureDefinition definition) {
+            this(definition.getSurfaceProperty().orElse(null));
+
+            brushFlagsRequirements.putAll(definition.getBrushFlagsRequirements());
+            surfaceFlagsRequirements.putAll(definition.getSurfaceFlagsRequirements());
+        }
+
+
+        public Builder setSurfaceProperty(String surfaceProperty) {
+            this.surfaceProperty = Objects.requireNonNull(surfaceProperty);
+            return this;
+        }
+
+        public Builder setRequiredFlags(BrushFlag... brushFlags) {
+            return setFlags(brushFlagsRequirements, true, brushFlags);
+        }
+        public Builder setForbiddenFlags(BrushFlag... brushFlags) {
+            return setFlags(brushFlagsRequirements, false, brushFlags);
+        }
+
+        public Builder setRequiredFlags(SurfaceFlag... surfaceFlags) {
+            return setFlags(surfaceFlagsRequirements, true, surfaceFlags);
+        }
+        public Builder setForbiddenFlags(SurfaceFlag... surfaceFlags) {
+            return setFlags(surfaceFlagsRequirements, false, surfaceFlags);
+        }
+
+        public Builder setIrrelevantFlags(BrushFlag... brushFlags) {
+            Arrays.asList(brushFlags).forEach(brushFlagsRequirements.keySet()::remove);
+            return this;
+        }
+        public Builder setIrrelevantFlags(SurfaceFlag... surfaceFlags) {
+            Arrays.asList(surfaceFlags).forEach(surfaceFlagsRequirements.keySet()::remove);
+            return this;
+        }
+
+        @SafeVarargs
+        private final <K> Builder setFlags(Map<K, Boolean> set, boolean state, K... ks) {
+            for (K k : ks) {
+                set.put(k, state);
+            }
+            return this;
+        }
+
+        public Builder clearBrushFlagRequirements() {
+            brushFlagsRequirements.clear();
+            return this;
+        }
+        public Builder clearSurfaceFlagRequirements() {
+            surfaceFlagsRequirements.clear();
+            return this;
+        }
+
+        public ToolTextureDefinition build() {
+            return new ToolTextureDefinition() {
+
+                private final String surfaceProperty = Builder.this.surfaceProperty;
+                private final Map<SurfaceFlag, Boolean> surfaceFlagsRequirements =
+                        Collections.unmodifiableMap(new HashMap<>(Builder.this.surfaceFlagsRequirements));
+                private final Map<BrushFlag, Boolean> brushFlagsRequirements =
+                        Collections.unmodifiableMap(new HashMap<>(Builder.this.brushFlagsRequirements));
+
+                @Override
+                public Optional<String> getSurfaceProperty() {
+                    return Optional.ofNullable(surfaceProperty);
+                }
+
+                @Override
+                public Map<BrushFlag, Boolean> getBrushFlagsRequirements() {
+                    return brushFlagsRequirements;
+                }
+
+                @Override
+                public Map<SurfaceFlag, Boolean> getSurfaceFlagsRequirements() {
+                    return surfaceFlagsRequirements;
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureSet.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureSet.java
@@ -1,0 +1,58 @@
+package info.ata4.bspsrc.modules.texture.tooltextures;
+
+import info.ata4.bsplib.app.SourceAppID;
+import info.ata4.bspsrc.modules.texture.tooltextures.definitions.SourceToolTextureDefinition;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Enum representing the set of tooltextures present in each game
+ */
+public enum ToolTextureSet {
+
+    SOURCE_2013(SourceAppID.UNKNOWN, SourceToolTextureDefinition.getAll());
+
+    private final int appId;
+    private final Map<String, ToolTextureDefinition> toolTextureDefinitions;
+
+    ToolTextureSet(int appId, Map<String, ToolTextureDefinition> toolTextureDefinitions) {
+        this.appId = appId;
+        this.toolTextureDefinitions = Collections.unmodifiableMap(new HashMap<>(toolTextureDefinitions));
+    }
+
+    private Builder builder() {
+        return new Builder(toolTextureDefinitions);
+    }
+
+    public static Map<String, ToolTextureDefinition> forGame(int appId) {
+        return Arrays.stream(values())
+                .filter(toolTextureSets -> toolTextureSets.appId == appId)
+                .findAny()
+                .orElse(SOURCE_2013)
+                .toolTextureDefinitions;
+    }
+
+    /**
+     * A Builder class for building a set of tooltexture definition
+     */
+    private static class Builder {
+
+        private final Map<String, ToolTextureDefinition> definitions = new HashMap<>();
+
+        public Builder(Map<String, ToolTextureDefinition> definitions) {
+            this.definitions.putAll(definitions);
+        }
+
+        public Builder putToolTextureDefinitions(Map<String, ToolTextureDefinition> definitions) {
+            this.definitions.putAll(definitions);
+            return this;
+        }
+
+        public Map<String, ToolTextureDefinition> build() {
+            return new HashMap<>(definitions);
+        }
+    }
+}

--- a/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureSet.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureSet.java
@@ -1,6 +1,7 @@
 package info.ata4.bspsrc.modules.texture.tooltextures;
 
 import info.ata4.bsplib.app.SourceAppID;
+import info.ata4.bspsrc.modules.texture.tooltextures.definitions.CsgoToolTextureDefinitions;
 import info.ata4.bspsrc.modules.texture.tooltextures.definitions.CssToolTextureDefinition;
 import info.ata4.bspsrc.modules.texture.tooltextures.definitions.SourceToolTextureDefinition;
 
@@ -19,6 +20,12 @@ public enum ToolTextureSet {
             SourceAppID.COUNTER_STRIKE_SOURCE,
             SOURCE_2013.builder()
                     .putToolTextureDefinitions(CssToolTextureDefinition.getAll())
+                    .build()
+    ),
+    COUNTER_STRIKE_GO(
+            SourceAppID.COUNTER_STRIKE_GO,
+            SOURCE_2013.builder()
+                    .putToolTextureDefinitions(CsgoToolTextureDefinitions.getAll())
                     .build()
     );
 

--- a/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureSet.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/ToolTextureSet.java
@@ -1,6 +1,7 @@
 package info.ata4.bspsrc.modules.texture.tooltextures;
 
 import info.ata4.bsplib.app.SourceAppID;
+import info.ata4.bspsrc.modules.texture.tooltextures.definitions.CssToolTextureDefinition;
 import info.ata4.bspsrc.modules.texture.tooltextures.definitions.SourceToolTextureDefinition;
 
 import java.util.Arrays;
@@ -13,7 +14,13 @@ import java.util.Map;
  */
 public enum ToolTextureSet {
 
-    SOURCE_2013(SourceAppID.UNKNOWN, SourceToolTextureDefinition.getAll());
+    SOURCE_2013(SourceAppID.UNKNOWN, SourceToolTextureDefinition.getAll()),
+    COUNTER_STRIKE_SOURCE(
+            SourceAppID.COUNTER_STRIKE_SOURCE,
+            SOURCE_2013.builder()
+                    .putToolTextureDefinitions(CssToolTextureDefinition.getAll())
+                    .build()
+    );
 
     private final int appId;
     private final Map<String, ToolTextureDefinition> toolTextureDefinitions;

--- a/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/definitions/CsgoToolTextureDefinitions.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/definitions/CsgoToolTextureDefinitions.java
@@ -1,0 +1,172 @@
+package info.ata4.bspsrc.modules.texture.tooltextures.definitions;
+
+import info.ata4.bsplib.struct.BrushFlag;
+import info.ata4.bsplib.struct.SurfaceFlag;
+import info.ata4.bspsrc.modules.texture.ToolTexture;
+import info.ata4.bspsrc.modules.texture.tooltextures.ToolTextureDefinition;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public enum CsgoToolTextureDefinitions implements ToolTextureDefinition {
+
+    GRENADE_CLIP(
+            ToolTexture.CSGO_GRENADECLIP,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_CURRENT_90, BrushFlag.CONTENTS_DETAIL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    DRONE_CLIP(
+            ToolTexture.CSGO_DRONECLIP,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_CURRENT_180, BrushFlag.CONTENTS_DETAIL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+
+    //Material specific clip textures
+    CLIP_CONCRETE(
+            ToolTexture.CSGO_CLIP_CONCRETE,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("concrete")
+                    .build()
+    ),
+    CLIP_DIRT(
+            ToolTexture.CSGO_CLIP_DIRT,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("dirt")
+                    .build()
+    ),
+    CLIP_GLASS(
+            ToolTexture.CSGO_CLIP_GLASS,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("glassfloor")
+                    .build()
+    ),
+    CLIP_GRASS(
+            ToolTexture.CSGO_CLIP_GRASS,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("grass")
+                    .build()
+    ),
+    CLIP_GRAVEL(
+            ToolTexture.CSGO_CLIP_GRAVEL,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("gravel")
+                    .build()
+    ),
+    CLIP_METAL(
+            ToolTexture.CSGO_CLIP_METAL,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("metal")
+                    .build()
+    ),
+    CLIP_METAL_SAND_BARREL(
+            ToolTexture.CSGO_CLIP_METAL_SAND_BARREL,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("metal_sand_barrel")
+                    .build()
+    ),
+    CLIP_METALGRATE(
+            ToolTexture.CSGO_CLIP_METALGRATE,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("metalgrate")
+                    .build()
+    ),
+    CLIP_METALVEHICLE(
+            ToolTexture.CSGO_CLIP_METALVEHICEL,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("metalvehicle")
+                    .build()
+    ),
+    CLIP_PLASTIC(
+            ToolTexture.CSGO_CLIP_PLASTIC,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("plastic")
+                    .build()
+    ),
+    CLIP_RUBBER(
+            ToolTexture.CSGO_CLIP_RUBBER,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("rubber")
+                    .build()
+    ),
+    CLIP_RUBBERTIRE(
+            ToolTexture.CSGO_CLIP_RUBBERTIRE,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("rubbertire")
+                    .build()
+    ),
+    CLIP_SAND(
+            ToolTexture.CSGO_CLIP_SAND,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("sand")
+                    .build()
+    ),
+    CLIP_SNOW(
+            ToolTexture.CSGO_CLIP_SNOW,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("snow")
+                    .build()
+    ),
+    CLIP_TILE(
+            ToolTexture.CSGO_CLIP_TILE,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("tile")
+                    .build()
+    ),
+    CLIP_WOOD(
+            ToolTexture.CSGO_CLIP_WOOD,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("wood")
+                    .build()
+    ),
+    CLIP_WOOD_BASKET(
+            ToolTexture.CSGO_CLIP_WOOD_BASKET,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("Wood_Basket")
+                    .build()
+    ),
+    CLIP_WOOD_CRATE(
+            ToolTexture.CSGO_CLIP_WOOD_CRATE,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .setSurfaceProperty("Wood_Crate")
+                    .build()
+    );
+
+    private final String materialName;
+    private final ToolTextureDefinition toolTextureDefinition;
+
+    CsgoToolTextureDefinitions(String materialName, ToolTextureDefinition toolTextureDefinition) {
+        this.materialName = Objects.requireNonNull(materialName);
+        this.toolTextureDefinition = Objects.requireNonNull(toolTextureDefinition);
+    }
+
+    public String getMaterialName() {
+        return materialName;
+    }
+
+    @Override
+    public Optional<String> getSurfaceProperty() {
+        return toolTextureDefinition.getSurfaceProperty();
+    }
+
+    @Override
+    public Map<BrushFlag, Boolean> getBrushFlagsRequirements() {
+        return toolTextureDefinition.getBrushFlagsRequirements();
+    }
+
+    @Override
+    public Map<SurfaceFlag, Boolean> getSurfaceFlagsRequirements() {
+        return toolTextureDefinition.getSurfaceFlagsRequirements();
+    }
+
+    public static Map<String, ToolTextureDefinition> getAll() {
+        return Arrays.stream(values())
+                .collect(Collectors.toMap(CsgoToolTextureDefinitions::getMaterialName, definition -> definition));
+    }
+}

--- a/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/definitions/CssToolTextureDefinition.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/definitions/CssToolTextureDefinition.java
@@ -1,0 +1,68 @@
+package info.ata4.bspsrc.modules.texture.tooltextures.definitions;
+
+import info.ata4.bsplib.struct.BrushFlag;
+import info.ata4.bsplib.struct.SurfaceFlag;
+import info.ata4.bspsrc.modules.texture.ToolTexture;
+import info.ata4.bspsrc.modules.texture.tooltextures.ToolTextureDefinition;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public enum CssToolTextureDefinition implements ToolTextureDefinition {
+    // Same as standard source2013 but doesn't have any surface flags
+    CLIP(
+            ToolTexture.CLIP,
+            new Builder(SourceToolTextureDefinition.CLIP)
+                    .clearSurfaceFlagRequirements()
+                    .build()
+    ),
+    // Same as standard source2013 but doesn't have any surface flags
+    NPC_CLIP(
+            ToolTexture.NPCCLIP,
+            new Builder(SourceToolTextureDefinition.NPC_CLIP)
+                    .clearSurfaceFlagRequirements()
+                    .build()
+    ),
+    // Same as standard source2013 but doesn't have any surface flags
+    PLAYER_CLIP(
+            ToolTexture.PLAYERCLIP,
+            new Builder(SourceToolTextureDefinition.PLAYER_CLIP)
+                    .clearSurfaceFlagRequirements()
+                    .build()
+    ),;
+
+    private final String materialName;
+    private final ToolTextureDefinition toolTextureDefinition;
+
+    CssToolTextureDefinition(String materialName, ToolTextureDefinition toolTextureDefinition) {
+        this.materialName = Objects.requireNonNull(materialName);
+        this.toolTextureDefinition = Objects.requireNonNull(toolTextureDefinition);
+    }
+
+    public String getMaterialName() {
+        return materialName;
+    }
+
+    @Override
+    public Optional<String> getSurfaceProperty() {
+        return toolTextureDefinition.getSurfaceProperty();
+    }
+
+    @Override
+    public Map<BrushFlag, Boolean> getBrushFlagsRequirements() {
+        return toolTextureDefinition.getBrushFlagsRequirements();
+    }
+
+    @Override
+    public Map<SurfaceFlag, Boolean> getSurfaceFlagsRequirements() {
+        return toolTextureDefinition.getSurfaceFlagsRequirements();
+    }
+
+    public static Map<String, ToolTextureDefinition> getAll() {
+        return Arrays.stream(values())
+                .collect(Collectors.toMap(CssToolTextureDefinition::getMaterialName, definition -> definition));
+    }
+}

--- a/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/definitions/SourceToolTextureDefinition.java
+++ b/src/main/java/info/ata4/bspsrc/modules/texture/tooltextures/definitions/SourceToolTextureDefinition.java
@@ -1,0 +1,181 @@
+package info.ata4.bspsrc.modules.texture.tooltextures.definitions;
+
+import info.ata4.bsplib.struct.BrushFlag;
+import info.ata4.bsplib.struct.SurfaceFlag;
+import info.ata4.bspsrc.modules.texture.ToolTexture;
+import info.ata4.bspsrc.modules.texture.tooltextures.ToolTextureDefinition;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Standard tooltexture definitions. By default we use these for every game.
+ * These are based on the source code found at <a href="github.com/ValveSoftware/source-sdk-2013">
+ *     github.com/ValveSoftware/source-sdk-2013</a>
+ *
+ * <p> Notable code references:
+ * <ul>
+ *     <li>Hardcoded Brush/Surface flag conversion. This is the reason why some brushes have additional/fewer flags
+ *     than the material specifies!
+ *     <p><a href="https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/utils/vbsp/map.cpp#L2711-L2730">
+ *         https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/utils/vbsp/map.cpp#L2711-L2730</a></li>
+ *     <li>Material definitions to flags conversion.
+ *     <p><a href="https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/utils/vbsp/textures.cpp#L85-L293">
+ *         https://github.com/ValveSoftware/source-sdk-2013/blob/master/sp/src/utils/vbsp/textures.cpp#L85-L293</a></li>
+ * </ul>
+ */
+public enum SourceToolTextureDefinition implements ToolTextureDefinition {
+    // General
+    AREAPORTAL(
+            ToolTexture.AREAPORTAL,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_AREAPORTAL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    BLOCK_BULLETS(
+            ToolTexture.BLOCKBULLETS,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_WINDOW, BrushFlag.CONTENTS_TRANSLUCENT)
+                    .setRequiredFlags(SurfaceFlag.SURF_TRANS, SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    BLOCK_LIGHT(
+            ToolTexture.BLOCKLIGHT,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_OPAQUE, BrushFlag.CONTENTS_DETAIL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    BLOCK_LOS(
+            ToolTexture.BLOCKLOS,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_BLOCKLOS, BrushFlag.CONTENTS_DETAIL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    INVISIBLE(
+            ToolTexture.INVIS,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_GRATE, BrushFlag.CONTENTS_TRANSLUCENT)
+                    .setForbiddenFlags(BrushFlag.CONTENTS_SOLID)
+                    .setRequiredFlags(SurfaceFlag.SURF_TRANS, SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    INVISIBLE_LADDER(
+            ToolTexture.INVISLADDER,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_GRATE, BrushFlag.CONTENTS_TRANSLUCENT, BrushFlag.CONTENTS_LADDER)
+                    .setForbiddenFlags(BrushFlag.CONTENTS_SOLID)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    NODRAW(
+            ToolTexture.NODRAW,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_SOLID)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    TRIGGER(
+            ToolTexture.TRIGGER,
+            new Builder()
+                    .setRequiredFlags(SurfaceFlag.SURF_NOLIGHT, SurfaceFlag.SURF_TRIGGER)
+                    .build()
+    ),
+
+    // Optimisation
+    HINT(
+            ToolTexture.HINT,
+            new Builder()
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_HINT, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    SKIP(
+            ToolTexture.SKIP,
+            new Builder()
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_SKIP, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+
+    // Clips
+    // CONTENTS_DETAIL in all games?
+    // surface property default_silent in all games?
+    CLIP(
+            ToolTexture.CLIP,
+            new Builder("default_silent")
+                    .setRequiredFlags(BrushFlag.CONTENTS_PLAYERCLIP, BrushFlag.CONTENTS_MONSTERCLIP, BrushFlag.CONTENTS_DETAIL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    // CONTENTS_DETAIL in all games?
+    // surface property default_silent in all games?
+    NPC_CLIP(
+            ToolTexture.NPCCLIP,
+            new Builder("default_silent")
+                    .setRequiredFlags(BrushFlag.CONTENTS_MONSTERCLIP, BrushFlag.CONTENTS_DETAIL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    // CONTENTS_DETAIL in all games?
+    PLAYER_CLIP(
+            ToolTexture.PLAYERCLIP,
+            new Builder()
+                    .setRequiredFlags(BrushFlag.CONTENTS_PLAYERCLIP, BrushFlag.CONTENTS_DETAIL)
+                    .setRequiredFlags(SurfaceFlag.SURF_NODRAW, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+
+    // Sky
+    // surface property default_silent in all games?
+    SKYBOX(
+            ToolTexture.SKYBOX,
+            new Builder("default_silent")
+                    .setRequiredFlags(BrushFlag.CONTENTS_SOLID)
+                    .setRequiredFlags(SurfaceFlag.SURF_SKY, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    ),
+    // surface property default_silent in all games?
+    SKYBOX_2D(
+            ToolTexture.SKYBOX2D,
+            new Builder("default_silent")
+                    .setRequiredFlags(BrushFlag.CONTENTS_SOLID)
+                    .setRequiredFlags(SurfaceFlag.SURF_SKY, SurfaceFlag.SURF_SKY2D, SurfaceFlag.SURF_NOLIGHT)
+                    .build()
+    );
+
+    private final String materialName;
+    private final ToolTextureDefinition toolTextureDefinition;
+
+    SourceToolTextureDefinition(String materialName, ToolTextureDefinition toolTextureDefinition) {
+        this.materialName = Objects.requireNonNull(materialName);
+        this.toolTextureDefinition = Objects.requireNonNull(toolTextureDefinition);
+    }
+
+    public String getMaterialName() {
+        return materialName;
+    }
+
+    @Override
+    public Optional<String> getSurfaceProperty() {
+        return toolTextureDefinition.getSurfaceProperty();
+    }
+
+    @Override
+    public Map<BrushFlag, Boolean> getBrushFlagsRequirements() {
+        return toolTextureDefinition.getBrushFlagsRequirements();
+    }
+
+    @Override
+    public Map<SurfaceFlag, Boolean> getSurfaceFlagsRequirements() {
+        return toolTextureDefinition.getSurfaceFlagsRequirements();
+    }
+
+    public static Map<String, ToolTextureDefinition> getAll() {
+        return Arrays.stream(values())
+                .collect(Collectors.toMap(SourceToolTextureDefinition::getMaterialName, definition -> definition));
+    }
+}


### PR DESCRIPTION
## Introduction
In the vbsp compilation process some brushsides get their texture name changed. This is caused vbsp trying to save space in the texinfo lump by reusing different texinfos. The algorithm for compacting texinfos can be looked up [here](https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/utils/vbsp/writebsp.cpp#L768), but I'll summarize the gist of it.
If the texinfo object of a brushside **is not** referenced by any face in the face lump, the algorithm tries to find and apply a "similar" texinfo object, which **is** referenced by a face. This primarily affects tooltextures (or probably all materials with `SURF_NODRAW`), as those are invisible and consequently don't need to generate any faces.

The previous algorithm in bspsrc used `brush/surface flags` to guess which texture a particular brushside previously used. However, as it basically only consisted of a handful of if statements, extending it for more game specific cases would have become quickly hard to maintain. Additionally, it didn't account for the `surface property` of a material, as described in #96.

 ## Changes
This PR introduces a new class `ToolTextureMatcher` to which the texture fixing process is delegated to.
It has a set of all possible/known tooltextures, which are dynamically created based on the `appId` to allow game specific tooltextures. Tooltextures in this set are mapped to a definition represented by the `ToolTextureDefinition` class. It consists of the tooltexture's `surface property` and a set of required/forbidden `brush/surface flags`.

The algorithm for fixing tooltexture simply tests each tooltexture definition with a particular brushside and returns it, if it matches.

#### Surface property
While the `brush/surface flags` are easy to retrieve for any particular brushside, the `surface property` isn't saved to the bsp. Rather it has to be looked up from the specific texture/material. Remembering that the texture may not be the correct/original one though, this seems impossible. 
However, the texinfo optimizing process described at the beginning actually makes sure, that if the texture changes, that the new one has **the same** `surface property`. Meaning, if we know the `surface property` of a particular texture and that texture happens to be the one on a brush side, we can be sure of it, even if the texture is not the original one.

Fixes: #99