### PR TITLE
Use java instead of javaw on Linux

### DIFF
--- a/scripts/bspsrc.sh
+++ b/scripts/bspsrc.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 BASEDIR=$(dirname "$0")
-javaw -jar "$BASEDIR/bspsrc.jar" $*
+java -jar "$BASEDIR/bspsrc.jar" $*


### PR DESCRIPTION
There is no `javaw` executable in the Linux's JDK